### PR TITLE
INTERLOK-2658 Add JsonSchema as an exclude since it is deprecated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -318,6 +318,7 @@ tasks.withType(com.github.spotbugs.SpotBugsTask) {
     html.enabled = true
   }
   includeFilter = new File("$rootDir/gradle/spotbugs-filter.xml")
+  excludeFilter = new File("$rootDir/gradle/spotbugs-exclude.xml")
 }
 javadoc.dependsOn offlinePackageList,umlJavadoc
 clean.dependsOn deleteDerbyLog

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter
+              xmlns="https://github.com/spotbugs/filter/3.0.0"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+
+  <!-- Ignore name shadowing for these, they're deprecated, and will be removed eventually -->
+  <Match>
+    <Class name="com.adaptris.core.transform.json.JsonSchemaService"/>
+    <Bug pattern="NM_SAME_SIMPLE_NAME_AS_SUPERCLASS" />
+  </Match>
+
+</FindBugsFilter>


### PR DESCRIPTION
Add a spotbugs-exclude file to filter on JsonSchema from the name shadow check.