### PR TITLE
INTERLOK-2759 Add support for rows-affected-metadata-key

### DIFF
--- a/src/main/java/com/adaptris/core/json/jdbc/BatchInsertJsonArray.java
+++ b/src/main/java/com/adaptris/core/json/jdbc/BatchInsertJsonArray.java
@@ -136,19 +136,20 @@ public class BatchInsertJsonArray extends InsertJsonObject {
     return accumulate(rc);
   }
 
+
   protected static int accumulate(int[] rc) throws SQLException {
-    AtomicInteger rowsAffected = new AtomicInteger(0);
+    int rowsAffected = 0;
     List<Integer> result = Arrays.asList(ArrayUtils.toObject(rc));
     if (result.contains(Statement.EXECUTE_FAILED)) {
       throw new SQLException("Batch Execution Failed.");
     }
-    result.stream().forEach((e) -> {
-      // not one of the Statement constants.
-      if (e >= 0) {
-        rowsAffected.addAndGet(e);
+    for (int i : rc) {
+      // Not Statement.EXECUTE_FAILED or SUCCESS_NO_INFO
+      if (i >= 0) {
+        rowsAffected += i;
       }
-    });
-    return rowsAffected.intValue();
+    }
+    return rowsAffected;
   }
 
   /**

--- a/src/main/java/com/adaptris/core/json/jdbc/InsertJsonArray.java
+++ b/src/main/java/com/adaptris/core/json/jdbc/InsertJsonArray.java
@@ -58,6 +58,7 @@ public class InsertJsonArray extends InsertJsonObject {
   @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
     Connection conn = null;
+    int rowsAffected = 0;
     try {
       log.trace("Beginning doService in {}", LoggingHelper.friendlyName(this));
       conn = getConnection(msg);
@@ -65,8 +66,9 @@ public class InsertJsonArray extends InsertJsonObject {
       LargeJsonArraySplitter splitter =
           new LargeJsonArraySplitter().withMessageFactory(AdaptrisMessageFactory.getDefaultInstance());
       for (AdaptrisMessage m : splitter.splitMessage(msg)) {
-        handleInsert(table(msg), conn, JsonUtil.mapifyJson(m, getNullConverter()));
+        rowsAffected += handleInsert(table(msg), conn, JsonUtil.mapifyJson(m, getNullConverter()));
       }
+      addUpdatedMetadata(rowsAffected, msg);
       JdbcUtil.commit(conn, msg);
     } catch (Exception e) {
       JdbcUtil.rollback(conn, msg);

--- a/src/main/java/com/adaptris/core/json/jdbc/InsertJsonObject.java
+++ b/src/main/java/com/adaptris/core/json/jdbc/InsertJsonObject.java
@@ -59,7 +59,7 @@ public class InsertJsonObject extends JdbcMapInsert {
     try {
       log.trace("Beginning doService in {}", LoggingHelper.friendlyName(this));
       conn = getConnection(msg);
-      handleInsert(table(msg), conn, JsonUtil.mapifyJson(msg, getNullConverter()));
+      addUpdatedMetadata(handleInsert(table(msg), conn, JsonUtil.mapifyJson(msg, getNullConverter())), msg);
       JdbcUtil.commit(conn, msg);
     } catch (Exception e) {
       JdbcUtil.rollback(conn, msg);

--- a/src/main/java/com/adaptris/core/json/jdbc/UpsertJsonObject.java
+++ b/src/main/java/com/adaptris/core/json/jdbc/UpsertJsonObject.java
@@ -58,7 +58,7 @@ public class UpsertJsonObject extends JdbcMapUpsert {
     try {
       log.trace("Beginning doService in {}", LoggingHelper.friendlyName(this));
       conn = getConnection(msg);
-      handleUpsert(table(msg), conn, JsonUtil.mapifyJson(msg, getNullConverter()));
+      addUpdatedMetadata(handleUpsert(table(msg), conn, JsonUtil.mapifyJson(msg, getNullConverter())), msg);
       JdbcUtil.commit(conn, msg);
     } catch (Exception e) {
       JdbcUtil.rollback(conn, msg);

--- a/src/test/java/com/adaptris/core/json/jdbc/InsertJsonArrayTest.java
+++ b/src/test/java/com/adaptris/core/json/jdbc/InsertJsonArrayTest.java
@@ -3,7 +3,6 @@ package com.adaptris.core.json.jdbc;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.json.jdbc.InsertJsonArray;
 
 public class InsertJsonArrayTest extends JdbcJsonInsertCase {
 
@@ -14,9 +13,11 @@ public class InsertJsonArrayTest extends JdbcJsonInsertCase {
 
   public void testService() throws Exception {
     createDatabase();
-    InsertJsonArray service = configureForTests(createService());
+    InsertJsonArray service = configureForTests(createService()).withRowsAffectedMetadataKey("rowsAffected");
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(ARRAY_CONTENT);
     execute(service, msg);
+    assertTrue(msg.headersContainsKey("rowsAffected"));
+    assertEquals("3", msg.getMetadataValue("rowsAffected"));
     doAssert(3);
   }
 
@@ -44,6 +45,7 @@ public class InsertJsonArrayTest extends JdbcJsonInsertCase {
     }
   }
 
+  @Override
   protected InsertJsonArray createService() {
     return new InsertJsonArray();
   }

--- a/src/test/java/com/adaptris/core/json/jdbc/InsertJsonObjectTest.java
+++ b/src/test/java/com/adaptris/core/json/jdbc/InsertJsonObjectTest.java
@@ -23,9 +23,11 @@ public class InsertJsonObjectTest extends JdbcJsonInsertCase {
 
   public void testService() throws Exception {
     createDatabase();
-    InsertJsonObject service = configureForTests(createService());
+    InsertJsonObject service = configureForTests(createService()).withRowsAffectedMetadataKey("rowsAffected");
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(OBJECT_CONTENT);
     execute(service, msg);
+    assertTrue(msg.headersContainsKey("rowsAffected"));
+    assertEquals("1", msg.getMetadataValue("rowsAffected"));
     doAssert(1);
   }
 
@@ -41,6 +43,7 @@ public class InsertJsonObjectTest extends JdbcJsonInsertCase {
     }
   }
 
+  @Override
   protected InsertJsonObject createService() {
     return new InsertJsonObject();
   }

--- a/src/test/java/com/adaptris/core/json/jdbc/JdbcJsonInsertCase.java
+++ b/src/test/java/com/adaptris/core/json/jdbc/JdbcJsonInsertCase.java
@@ -114,8 +114,8 @@ public abstract class JdbcJsonInsertCase extends ServiceCase {
 
   protected abstract JdbcMapInsert createService();
 
-  protected static <T> T configureForTests(T t) {
-    JdbcMapInsert service = (JdbcMapInsert) t;
+  protected static <T extends JdbcMapInsert> T configureForTests(T t) {
+    JdbcMapInsert service = t;
     JdbcConnection connection = new JdbcConnection();
     connection.setConnectUrl(JDBC_URL);
     connection.setDriverImp(JDBC_DRIVER);

--- a/src/test/java/com/adaptris/core/json/jdbc/UpsertJsonArrayTest.java
+++ b/src/test/java/com/adaptris/core/json/jdbc/UpsertJsonArrayTest.java
@@ -24,16 +24,19 @@ public class UpsertJsonArrayTest extends UpsertJsonCase {
 
   public void testService_InsertArray() throws Exception {
     createDatabase();
-    UpsertJsonArray service = (UpsertJsonArray) configureForTests(createService().withId(ID_ELEMENT_VALUE));
+    UpsertJsonArray service =
+        configureForTests(createService()).withId(ID_ELEMENT_VALUE).withRowsAffectedMetadataKey("rowsAffected");
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(ARRAY_CONTENT);
     execute(service, msg);
+    assertTrue(msg.headersContainsKey("rowsAffected"));
+    assertEquals("3", msg.getMetadataValue("rowsAffected"));
     doAssert(3);
   }
 
   public void testService_UpdateArray() throws Exception {
     createDatabase();
     populateDatabase();
-    UpsertJsonArray service = (UpsertJsonArray) configureForTests(createService().withId(ID_ELEMENT_VALUE));
+    UpsertJsonArray service = configureForTests(createService()).withId(ID_ELEMENT_VALUE);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(ARRAY_CONTENT);
     execute(service, msg);
     doAssert(3);

--- a/src/test/java/com/adaptris/core/json/jdbc/UpsertJsonObjectTest.java
+++ b/src/test/java/com/adaptris/core/json/jdbc/UpsertJsonObjectTest.java
@@ -44,10 +44,12 @@ public class UpsertJsonObjectTest extends UpsertJsonCase {
   public void testService_Update() throws Exception {
     createDatabase();
     populateDatabase();
-    UpsertJsonObject service = configureForTests(createService());
+    UpsertJsonObject service = configureForTests(createService()).withRowsAffectedMetadataKey("rowsAffected");
     service.setIdField(ID_ELEMENT_VALUE);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(OBJECT_CONTENT);
     execute(service, msg);
+    assertTrue(msg.headersContainsKey("rowsAffected"));
+    assertEquals("1", msg.getMetadataValue("rowsAffected"));
     doAssert(1);
     checkDob(CAROL, DOB);
   }


### PR DESCRIPTION
- Add support for the rows-affected-metadata-key in JSON insert/upsert
- Refactor the executeBatch method for coverage.