### PR TITLE
Interlok-2852 added filter condition to aggregator

### DIFF
--- a/src/main/java/com/adaptris/core/json/aggregator/JsonArrayAggregator.java
+++ b/src/main/java/com/adaptris/core/json/aggregator/JsonArrayAggregator.java
@@ -61,7 +61,7 @@ public class JsonArrayAggregator extends MessageAggregatorImpl {
   public void joinMessage(AdaptrisMessage original, Collection<AdaptrisMessage> messages) throws CoreException {
     try (Writer w = new BufferedWriter(original.getWriter()); JsonGenerator generator = mapper.getFactory().createGenerator(w)) {
       generator.writeStartArray();
-      for (AdaptrisMessage msg : messages) {
+      for (AdaptrisMessage msg : filter(messages)) {
         write(msg, generator);
         overwriteMetadata(msg, original);
       }

--- a/src/main/java/com/adaptris/core/json/aggregator/JsonArrayArrayAggregator.java
+++ b/src/main/java/com/adaptris/core/json/aggregator/JsonArrayArrayAggregator.java
@@ -60,7 +60,7 @@ public class JsonArrayArrayAggregator extends MessageAggregatorImpl {
   public void joinMessage(AdaptrisMessage original, Collection<AdaptrisMessage> messages) throws CoreException {
     try (Writer w = new BufferedWriter(original.getWriter()); JsonGenerator generator = mapper.getFactory().createGenerator(w)) {
       generator.writeStartArray();
-      for (AdaptrisMessage msg : messages) {
+      for (AdaptrisMessage msg : filter(messages)) {
         write(msg, generator);
         overwriteMetadata(msg, original);
       }

--- a/src/test/java/com/adaptris/core/json/aggregator/JsonArrayAggregatorFilterTest.java
+++ b/src/test/java/com/adaptris/core/json/aggregator/JsonArrayAggregatorFilterTest.java
@@ -1,0 +1,114 @@
+package com.adaptris.core.json.aggregator;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.Service;
+import com.adaptris.core.ServiceCase;
+import com.adaptris.core.json.JsonToMetadata;
+import com.adaptris.core.services.conditional.conditions.ConditionMetadata;
+import com.adaptris.core.services.conditional.operator.Equals;
+import com.adaptris.core.services.splitter.SplitJoinService;
+import com.adaptris.core.services.splitter.json.JsonArraySplitter;
+import org.apache.commons.io.IOUtils;
+import org.json.JSONArray;
+
+import java.io.File;
+
+public class JsonArrayAggregatorFilterTest extends ServiceCase {
+
+  private static final String AGX_GROWERS_LIST_URL = "/growers-sync16.json";
+
+
+  public JsonArrayAggregatorFilterTest() { super("Json Array Aggregator Filter Test"); }
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+  }
+
+  @Override
+  protected Object retrieveObjectForSampleConfig() {
+    SplitJoinService service = new SplitJoinService();
+    service.setService(new JsonToMetadata());
+    service.setSplitter(new JsonArraySplitter());
+
+    final JsonArrayAggregator jsonArrayAggregator = new JsonArrayAggregator();
+    final ConditionMetadata conditionMetadata = new ConditionMetadata();
+    conditionMetadata.setMetadataKey("IsDeleted");
+
+    final Equals equalsOperation = new Equals();
+    equalsOperation.setValue("false");
+    conditionMetadata.setOperator(equalsOperation);
+    jsonArrayAggregator.setFilterCondition(conditionMetadata);
+    service.setAggregator(jsonArrayAggregator);
+    return service;
+  }
+
+  public void testListFilteringWithBooleanMetadata() throws Exception {
+    // Read in json as Text
+    final String fileContents = IOUtils.toString(
+            this.getClass().getResourceAsStream(AGX_GROWERS_LIST_URL),"UTF-8"
+    );
+
+    // Create AdaptrisMessage and the SplitJoinService
+    AdaptrisMessage original = AdaptrisMessageFactory.getDefaultInstance().newMessage(fileContents);
+    final Service service = (Service) retrieveObjectForSampleConfig();
+
+    // run
+    execute(service, original);
+
+    // Now check payload to ensure we did filter
+    assertNotNull(original.getPayload());
+    String resultPayload = new String(original.getPayload(), "UTF8");
+    // TODO need to do json array based comparision to show that the arrays are different rather than string difference,
+    // which will always be due to pretty printing
+    assertEquals(false, fileContents.equals(resultPayload));
+
+    final JSONArray aggregatedJsonResult = new JSONArray(resultPayload);
+    assertEquals(62, aggregatedJsonResult.length());
+
+    final JSONArray initialJsonArray = new JSONArray(fileContents);
+    assertEquals(146, initialJsonArray.length());
+  }
+
+  public void testListFilteringWithNullCondition() throws Exception {
+    File file = new File(AGX_GROWERS_LIST_URL);
+    final String fileContents = IOUtils.toString(
+            this.getClass().getResourceAsStream(AGX_GROWERS_LIST_URL),"UTF-8"
+    );
+
+    // Create AdaptrisMessage and the SplitJoinService
+    AdaptrisMessage original = AdaptrisMessageFactory.getDefaultInstance().newMessage(fileContents);
+    final SplitJoinService service = (SplitJoinService) retrieveObjectForSampleConfig();
+    ((JsonArrayAggregator)service.getAggregator()).setFilterCondition(null);
+
+    // run
+    execute(service, original);
+
+    // Now check payload to ensure ensure no change
+    assertNotNull(original.getPayload());
+    String resultPayload = new String(original.getPayload(), "UTF8");
+    // TODO need to introduce json array based comparison here to ensure original and result are the same
+
+    final JSONArray aggregatedJsonResult = new JSONArray(resultPayload);
+    assertEquals(146, aggregatedJsonResult.length());
+
+    final JSONArray initialJsonArray = new JSONArray(fileContents);
+    assertEquals(146, initialJsonArray.length());
+  }
+
+  public void testRetainFilterExceptionsMessages() throws Exception {
+    final JsonArrayAggregator jsonArrayAggregator = new JsonArrayAggregator();
+    // Test default
+    assertNull(jsonArrayAggregator.getRetainFilterExceptionsMessages());
+    assertEquals(Boolean.FALSE, jsonArrayAggregator.retainFilterExceptionsMessages());
+    // Test flag with true
+    jsonArrayAggregator.setRetainFilterExceptionsMessages(true);
+    assertEquals(Boolean.TRUE, jsonArrayAggregator.getRetainFilterExceptionsMessages());
+    assertEquals(Boolean.TRUE, jsonArrayAggregator.retainFilterExceptionsMessages());
+    // Test flag with null
+    jsonArrayAggregator.setRetainFilterExceptionsMessages(null);
+    assertNull(jsonArrayAggregator.getRetainFilterExceptionsMessages());
+    assertEquals(Boolean.FALSE, jsonArrayAggregator.retainFilterExceptionsMessages());
+  }
+}

--- a/src/test/java/com/adaptris/core/json/aggregator/JsonArrayArrayAggregatorTest.java
+++ b/src/test/java/com/adaptris/core/json/aggregator/JsonArrayArrayAggregatorTest.java
@@ -50,6 +50,19 @@ public class JsonArrayArrayAggregatorTest extends ServiceCase {
     assertEquals("carol", context.read("$[2].firstname"));
   }
 
+  public void testAggregate_WithFilter() throws Exception {
+    AdaptrisMessage original = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello");
+    List<AdaptrisMessage> msgs = create(String.format("[%s, %s]", OBJECT_CONTENT_1, OBJECT_CONTENT_2), OBJECT_CONTENT_3);
+    JsonArrayArrayAggregator aggr = new JsonArrayArrayAggregator();
+    aggr.setFilterCondition(new JsonArrayAggregatorTest.FilterOutBobCondition());
+    aggr.joinMessage(original, msgs);
+    assertNotSame("Hello", original.getContent());
+    // Should be in order.
+    ReadContext context = JsonPath.parse(original.getInputStream(), jsonConfig);
+    assertNotNull(context.read("$[0].firstname"));
+    assertEquals("carol", context.read("$[0].firstname"));
+  }
+
   public void testAggregator_NotJson() throws Exception {
     AdaptrisMessage original = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello");
     List<AdaptrisMessage> msgs = create("not", "valid", "json");
@@ -58,7 +71,6 @@ public class JsonArrayArrayAggregatorTest extends ServiceCase {
     assertNotSame("Hello", original.getContent());
     assertEquals("[]", StringUtils.deleteWhitespace(original.getContent()));
   }
-
 
   @Override
   protected Object retrieveObjectForSampleConfig() {

--- a/src/test/resources/growers-sync16.json
+++ b/src/test/resources/growers-sync16.json
@@ -1,0 +1,878 @@
+[
+    {
+        "ID": "a2b1c300-2f8f-01c2-3b00-f12fbe188467",
+        "ModifiedOn": "2016-09-09T15:03:40.729Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "9c78cb00-3363-01c2-3d00-f1d1be188467",
+        "ModifiedOn": "2008-10-03T21:19:46Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "1a4ff603-8bfa-454f-80e0-52108a81d367",
+        "ModifiedOn": "2017-08-03T19:18:31.996667Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "adaf0c04-8e19-4871-b9f8-d64c52c365c5",
+        "ModifiedOn": "2015-03-07T23:34:48Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "50090905-12be-4176-b3e2-acda18e28d79",
+        "ModifiedOn": "2017-11-17T14:47:26.949Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "80632205-2ad4-47cf-9f9c-e284b7e78b18",
+        "ModifiedOn": "2017-10-27T16:40:35.012057Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "839d8a08-0a28-4554-be4b-c09d29d6dc5e",
+        "ModifiedOn": "2014-07-13T22:59:45Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "546be308-e314-4a35-ba95-5eeb2273b272",
+        "ModifiedOn": "2015-06-12T04:41:02Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "c6740609-a468-41be-8742-9a6f7b4aeeff",
+        "ModifiedOn": "2015-06-12T04:29:12Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "ea4b340c-d72a-4307-91ef-70820ae577b9",
+        "ModifiedOn": "2014-07-13T22:56:08Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "0778c40c-09d1-4898-9858-c6b96c62a385",
+        "ModifiedOn": "2017-05-12T14:04:46.6Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "2dccb50f-2a19-4f16-b85f-6f29c76ae92b",
+        "ModifiedOn": "2017-09-18T23:31:15.575Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "d57cce10-5c27-4cc5-a99d-378e12d6182b",
+        "ModifiedOn": "2017-03-01T19:23:48.771448Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "7a60ed18-77a0-4379-9322-d527b099d977",
+        "ModifiedOn": "2015-06-16T18:24:40Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "366aea1d-1b85-4549-b0cb-0af5a77021d0",
+        "ModifiedOn": "2014-04-23T14:49:20Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "edb1ba20-6b22-4ee8-8a41-3dc4d71d68db",
+        "ModifiedOn": "2016-10-20T21:17:09.573706Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "9e2c0121-8bc0-441f-8258-7be3962e6952",
+        "ModifiedOn": "2017-06-12T16:17:57.36Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "82c0c121-ec1c-4312-b8b8-70f1946510e3",
+        "ModifiedOn": "2013-04-11T19:58:54Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "b2ffcd25-e334-489e-b251-05e7483d6d98",
+        "ModifiedOn": "2015-03-18T15:21:59Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "58b28f28-fcba-4437-bd8b-f16fac3cd8ed",
+        "ModifiedOn": "2014-05-28T01:55:01Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "be562b33-a7e5-4d50-b9e6-760f1dfcc0a4",
+        "ModifiedOn": "2017-06-14T14:26:49.47Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "a647a034-c116-476d-9a6e-23af99c8e1df",
+        "ModifiedOn": "2016-12-02T20:19:27.547639Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "f79e9637-e783-4ab1-91d9-5fb97b5c34b1",
+        "ModifiedOn": "2015-07-24T14:47:58Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "3e117838-a723-42b6-8316-c3d739305af6",
+        "ModifiedOn": "2017-05-23T16:38:02.526667Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "d575623b-ebd6-42f9-b586-d6c161ad635e",
+        "ModifiedOn": "2015-03-18T00:51:50Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "a56cbe3d-1c76-403f-b8c7-1553cfd883a4",
+        "ModifiedOn": "2016-08-12T17:13:58.489Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "741e6641-fa7b-4be3-924a-8d8501e68d00",
+        "ModifiedOn": "2014-07-13T23:10:54Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "d321fc47-e1d0-4afb-b604-8a9abcb0f9dc",
+        "ModifiedOn": "2017-09-21T18:46:20.985297Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "2334e649-cf47-406a-8ece-c47fb7f918ff",
+        "ModifiedOn": "2009-12-02T16:24:18.2Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "0d83154a-d0ac-49de-98f3-42f60c48a5a7",
+        "ModifiedOn": "2016-08-17T14:46:24.273Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "7e26704e-424f-4a43-800a-fa46345df769",
+        "ModifiedOn": "2011-05-24T00:31:15Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "6da44f4f-2dcc-4dee-af40-ac34782d5d04",
+        "ModifiedOn": "2016-09-16T19:07:55.239Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "4ba72050-38ed-476c-a0f8-66adc7bd54fa",
+        "ModifiedOn": "2013-05-14T18:52:22Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "b9c37553-3739-4377-a7e9-3d7c309f7cbe",
+        "ModifiedOn": "2010-03-30T18:59:40Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "7eef5456-1f22-477c-856f-808148007a34",
+        "ModifiedOn": "2016-09-01T15:26:14.686Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "79c77a58-49c9-4d87-a7a8-03f7f4c97a03",
+        "ModifiedOn": "2017-05-12T16:46:26.453Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "4a37ec58-35ee-4933-a707-098efc75591e",
+        "ModifiedOn": "2015-12-08T21:45:16Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "d508d25a-ec17-4c05-8cda-1d80edcda816",
+        "ModifiedOn": "2011-10-06T19:57:30Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "65e85565-ab2d-46df-8b6d-ed5b227bfd68",
+        "ModifiedOn": "2014-04-30T20:37:54Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "a5db4f66-548c-4778-bff5-b39b53cdd36c",
+        "ModifiedOn": "2013-05-05T01:54:41Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "f7c91a6a-42a2-404d-b4fa-2dc587fffed6",
+        "ModifiedOn": "2017-06-05T14:20:21.613Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "b2dad75b-6004-4379-a522-6108618d1cbd",
+        "ModifiedOn": "2018-03-29T20:53:37.472869Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "53389c5c-9934-4e2c-90a1-5ce30ab9fadb",
+        "ModifiedOn": "2010-11-08T15:14:14Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "d21c9261-5bb5-4870-ab3d-7441c0318f63",
+        "ModifiedOn": "2007-10-19T17:12:59Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "16dd0162-f63f-4451-924b-39efffb248d6",
+        "ModifiedOn": "2017-02-09T19:49:13Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "d85f4765-2c2c-4093-83bb-836a0cde1507",
+        "ModifiedOn": "2017-10-19T15:30:17.906Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "7e6b8a6c-c668-4a5d-87f3-a955c7aa2cd9",
+        "ModifiedOn": "2009-12-03T17:00:09.6Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "6fd17772-5136-4864-8287-a6af3ce64960",
+        "ModifiedOn": "2016-06-02T20:19:52.512Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "a26bf873-0add-4bdd-b680-d4e67877915a",
+        "ModifiedOn": "2017-09-18T15:29:09.861817Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "7f2bf57c-7832-483b-ac26-e145affac328",
+        "ModifiedOn": "2017-01-03T17:17:00.676Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "655f047f-a313-4c9c-aae7-a52e3669a52d",
+        "ModifiedOn": "2015-06-11T19:56:52Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "cd6f1880-aff1-4254-a5cf-6358ffc221df",
+        "ModifiedOn": "2013-03-28T16:00:45Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "c87cd880-e7c0-01c2-3b00-d16bbe188467",
+        "ModifiedOn": "2016-08-17T14:46:02.526Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "6b8e6381-7273-4708-b55b-e48cf2cac126",
+        "ModifiedOn": "2009-08-25T05:51:02Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "253a8187-d0b5-4810-892a-d1299585304d",
+        "ModifiedOn": "2014-02-23T23:38:19Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "4bfd798a-7607-46d8-b1fc-e186c27a3777",
+        "ModifiedOn": "2007-11-23T20:29:30Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "6be29e8d-202c-4ec8-bee7-e6232ad02713",
+        "ModifiedOn": "2017-09-18T20:34:48.964597Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "7b3a8991-4cc2-4a6e-a9b1-97fabccb4f7c",
+        "ModifiedOn": "2015-06-16T18:22:53Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "735c9d97-31eb-4b6b-bce8-dda96bc04c8d",
+        "ModifiedOn": "2015-06-12T04:35:48Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "caa7e597-7120-4a50-9e7b-67d929926784",
+        "ModifiedOn": "2014-07-13T22:48:54Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "df7bfa9d-c213-4d41-9a69-74ca9f376aa8",
+        "ModifiedOn": "2017-02-07T15:53:29.7Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "9d0e549f-3d4f-4e52-94d3-7446f8202290",
+        "ModifiedOn": "2015-09-22T17:52:40Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "724e90a2-89bb-4d0c-bd3b-24498542072e",
+        "ModifiedOn": "2017-11-17T14:47:41.476Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "a53aa8a2-0415-4366-ab21-3255aee4be0e",
+        "ModifiedOn": "2009-10-12T15:01:33Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "f4ee59a3-71eb-49f6-afab-0f82bda13c1f",
+        "ModifiedOn": "2016-04-06T13:27:49Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "23c2cfa6-504c-4ef4-8bf8-456f490253ed",
+        "ModifiedOn": "2008-11-20T16:28:16Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "c4cef2a6-bf41-43f2-a59f-767f65bc60f1",
+        "ModifiedOn": "2015-06-11T21:07:59Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "578a33a7-86a0-40b2-af88-025da6bf116a",
+        "ModifiedOn": "2015-07-24T14:49:01Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "c90926a8-ce3b-45ca-bf80-97e26ca050d9",
+        "ModifiedOn": "2016-08-17T14:44:39.336Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "6d26fca9-4ccb-4233-8fb0-8d7ba5338dc2",
+        "ModifiedOn": "2013-04-11T19:54:48Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "b29d2cac-472a-4f18-8ff6-e79a20a87329",
+        "ModifiedOn": "2016-08-17T14:45:42.703Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "47da1ead-e01d-45f7-b01d-4b537b810487",
+        "ModifiedOn": "2017-11-17T14:47:18.049Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "b24ebaae-89f5-4ef4-a1f5-864c964e4473",
+        "ModifiedOn": "2015-04-02T01:23:46Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "ec0207af-968d-4d93-bb30-10b62bb7f224",
+        "ModifiedOn": "2016-09-15T13:50:01.717Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "c3c1c9b1-3c4c-4159-b2a5-2879655adc08",
+        "ModifiedOn": "2014-11-13T21:24:26Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "5b1b74b4-8bb3-4792-bc51-71d82438b3a3",
+        "ModifiedOn": "2017-05-26T19:37:04.463333Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "c8e628b5-508b-46a0-ad9d-ea6528ead266",
+        "ModifiedOn": "2014-10-20T22:32:40Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "e6eb87b9-3abb-4ff2-a209-eb02ea351e34",
+        "ModifiedOn": "2015-06-11T21:37:21Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "923d03bc-731f-4888-90dc-d069491412b7",
+        "ModifiedOn": "2012-03-12T14:56:04Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "62b716be-19c6-41af-8ff2-8a81e0b49227",
+        "ModifiedOn": "2014-07-01T17:09:30Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "c3f5aebf-372a-4024-8d04-568c4f25e25a",
+        "ModifiedOn": "2015-10-20T16:01:15Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "934a35c8-48b4-4015-ac8e-a0276f529efb",
+        "ModifiedOn": "2015-06-12T04:27:44Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "d7243ec8-d06f-4f38-91bb-596c50e6d6fd",
+        "ModifiedOn": "2015-07-24T14:46:44Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "43efa8ca-d1a0-4c4a-9bc8-8ec12cda9e7c",
+        "ModifiedOn": "2015-06-12T04:33:34Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "4626b9cd-1c8d-4870-ba47-5e2de395618e",
+        "ModifiedOn": "2015-03-18T00:56:19Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "3c965dce-4967-41df-bb02-2f185fb7b8d6",
+        "ModifiedOn": "2015-05-11T15:42:55Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "fc161bcf-52f0-4b5d-a426-fe3a8248d5da",
+        "ModifiedOn": "2015-11-11T20:34:45Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "1c01abcf-382e-42c4-950a-42714e15ec5c",
+        "ModifiedOn": "2014-07-13T23:07:18Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "12ec88d6-71da-4c3d-9413-0df3859b64ed",
+        "ModifiedOn": "2016-08-17T14:44:53.198Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "0bd8fcd7-1450-4ce3-b7eb-3651275821c7",
+        "ModifiedOn": "2012-03-12T14:42:05Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "cb01c7e0-0098-454a-a0fa-0e27fd31fde3",
+        "ModifiedOn": "2015-03-09T18:02:11Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "a16f98e5-4123-41df-9637-6923161be8bd",
+        "ModifiedOn": "2007-04-09T15:51:31Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "22a5e7e7-cb6c-4ff6-a904-134cfb906b76",
+        "ModifiedOn": "2013-04-11T19:56:18Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "e21031e8-b581-4377-b864-f8dfac2aeacb",
+        "ModifiedOn": "2016-08-17T14:45:07.62Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "cb7680ea-6ef7-4b64-b28d-e287e73d8d71",
+        "ModifiedOn": "2012-04-06T15:41:07Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "2524f3eb-c55f-40f4-8dd4-1412d1c70856",
+        "ModifiedOn": "2013-09-12T17:56:35Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "986d48ec-9330-4436-9ad9-9ddb11c77154",
+        "ModifiedOn": "2016-08-17T16:09:28.809Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "6b57f8ed-1933-4d0e-9126-fbe90bcdbe62",
+        "ModifiedOn": "2017-11-17T14:47:34.333Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "ac5c72f0-ec6a-4153-9cc2-3d75a2cf95fc",
+        "ModifiedOn": "2014-05-28T02:01:47Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "4c69eff1-844f-4cac-8f00-6c393a3816a7",
+        "ModifiedOn": "2017-05-26T20:31:58.433333Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "5bb007f2-bec3-40f8-913a-2883c9d3e044",
+        "ModifiedOn": "2017-09-13T23:50:23.406863Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "38c0acf3-94a1-4b79-8157-22ad7533b4cb",
+        "ModifiedOn": "2006-10-11T14:48:28Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "5d668cf7-bb68-4f62-b3ab-94d92703a0b9",
+        "ModifiedOn": "2015-06-16T18:25:37Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "e3b488fe-a34e-4ec3-875f-1c233609b03d",
+        "ModifiedOn": "2015-06-12T04:32:13Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "f56723ff-feb1-4d31-9b26-dc32de3e1dc7",
+        "ModifiedOn": "2016-08-26T19:19:19.98Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "b0bcff45-245a-4663-8ea2-19d25104e46d",
+        "ModifiedOn": "2017-12-15T22:25:23.786667Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "32ce5bfa-ac62-4e1f-9abe-ed1dc1ae2a5d",
+        "ModifiedOn": "2018-01-15T17:42:20.596667Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "85a6e41b-483b-4b63-a1a5-4a89f4590ddc",
+        "ModifiedOn": "2017-12-21T17:15:24.043333Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "53689beb-c6e3-4422-a7cd-e7b16f69b770",
+        "ModifiedOn": "2018-02-28T20:18:14.56Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "a4cf9ad7-f341-434e-9682-285f0edfcc8e",
+        "ModifiedOn": "2018-03-07T13:51:52.909387Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "ce0eca2f-4783-44bd-8d8f-47dface2cae0",
+        "ModifiedOn": "2018-03-07T14:21:53.316667Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "5ddd2c00-8e71-474c-8e9a-eaa11633ca27",
+        "ModifiedOn": "2016-09-01T16:24:33.987Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "f0d26e28-bd56-405e-ba3b-6c55af32984c",
+        "ModifiedOn": "2016-01-06T21:54:35Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "8e96be53-f551-4085-9508-841ea9cf3de1",
+        "ModifiedOn": "2019-02-28T16:27:02.962762Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "901a586f-73a9-4c9f-8937-dc756f0b1948",
+        "ModifiedOn": "2019-02-11T19:53:35.159507Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "00a146f2-3e6e-4d56-b50a-2a50a2b1d25b",
+        "ModifiedOn": "2019-03-15T21:02:57.642569Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "44ff41e9-144a-45c4-8b01-7b3f4b583cfb",
+        "ModifiedOn": "2019-04-17T16:23:49Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "3151d68b-8c3b-4b29-ba66-76f6f0ffffbe",
+        "ModifiedOn": "2018-07-03T16:03:48.99Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "331bcca2-4139-441e-97c7-449bc1fd488f",
+        "ModifiedOn": "2018-06-27T15:12:20.473333Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "2f0051c9-af4e-4b26-ae56-9c6f99ac21dd",
+        "ModifiedOn": "2018-12-05T16:34:07Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "aa713d51-8fa8-447a-9281-98904278271a",
+        "ModifiedOn": "2018-10-14T02:05:54.959123Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "9753a7f9-ae41-4aa1-83f5-f9a6c1e1137e",
+        "ModifiedOn": "2018-12-12T21:05:56Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "57a8781c-04a7-4ba1-a574-e91b32717c2e",
+        "ModifiedOn": "2018-05-10T13:20:40.377Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "8edc9518-230c-4901-884c-046bce16af70",
+        "ModifiedOn": "2019-04-09T12:35:47Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "0483ef8a-2395-4eb3-aea6-63a3dc475b65",
+        "ModifiedOn": "2019-04-11T16:46:12.264079Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "7eead219-4057-428c-ad3b-d8cba7c5a4d4",
+        "ModifiedOn": "2019-05-14T15:37:01Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "9510050f-ac4a-4b81-9d01-0d19afda6906",
+        "ModifiedOn": "2018-02-28T20:15:07.82Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "86288d3a-e46a-494d-aedb-e22cfa6e856a",
+        "ModifiedOn": "2019-03-14T20:44:35.988327Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "c57a01b3-b537-4c27-af7a-c0d1af188460",
+        "ModifiedOn": "2018-04-25T13:24:59Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "d8bad084-bc88-469e-89ee-c9d7e03a4d72",
+        "ModifiedOn": "2019-01-15T16:01:35.792Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "3590dc1d-b96f-49b3-a2b7-d7be4e804b2b",
+        "ModifiedOn": "2017-05-19T00:12:08.972Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "a17bf092-42e7-4b03-ae0c-9678912113b2",
+        "ModifiedOn": "2019-02-26T16:27:30.897517Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "2d88b4cd-d0b6-4f98-bcb8-6a7622e987ad",
+        "ModifiedOn": "2019-02-19T18:02:04.173892Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "26f6e610-3b03-4628-b35b-29792cfe24cf",
+        "ModifiedOn": "2018-03-27T12:50:30.945Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "f91405dc-6211-4134-9530-abc45dae9fac",
+        "ModifiedOn": "2017-05-19T17:06:45.042Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "2fef5143-6ab6-4595-a7b4-43d6ae0a39c6",
+        "ModifiedOn": "2018-10-15T21:12:04.457075Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "4bd12dc0-211c-4992-9292-cf40ec1c3fcc",
+        "ModifiedOn": "2018-12-02T20:53:36Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "d7bb579e-d38b-43cc-a738-1ea5aa8cc9b0",
+        "ModifiedOn": "2018-09-07T18:08:08.368Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "86fbf37b-192b-4f1b-93c2-cf32e2d72096",
+        "ModifiedOn": "2018-02-09T19:37:44Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "0d629226-404d-4676-8b99-95539e8c424d",
+        "ModifiedOn": "2011-12-13T20:33:03Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "3c7886f3-e6bf-4dd5-8abb-1376681ef4ee",
+        "ModifiedOn": "2018-07-23T20:08:05.37Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "25248996-e05a-4431-b22a-402fa2881390",
+        "ModifiedOn": "2018-07-23T18:28:00Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "3dc05139-9d3c-4c77-8834-c93e9788a18c",
+        "ModifiedOn": "2018-07-25T18:06:38.499521Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "67e273b6-c738-4473-88c1-bc356d75408a",
+        "ModifiedOn": "2018-08-01T13:57:50.402Z",
+        "IsDeleted": false,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "891a8fb8-3c05-4251-8b2f-56035a01fc4c",
+        "ModifiedOn": "2018-07-23T18:34:15Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    },
+    {
+        "ID": "2ac3a46a-b7d5-4c00-bad9-5b0847462e3b",
+        "ModifiedOn": "2018-05-30T13:17:03.279Z",
+        "IsDeleted": true,
+        "SchemaVersion": "4.0"
+    }
+]


### PR DESCRIPTION
This code requires the latest pull requests on interlok-core: new conditionals and filter-splitter3 otherwise compilation will fail.

The following aggregators have been updated to filter the messages with an optional condition, tests have been added.
This pull requests goes together with the interlok-core equivalent one.
