### PR TITLE
INTERLOK-2892 Add JSON Array / Lines support.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,35 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Setup Ubuntu
+      run: |
+        sudo apt-get -y update
+        sudo apt-get -y install haveged
+        sudo systemctl enable haveged
+        sudo systemctl restart haveged
+    - name: Gradle Wrapper Cache
+      uses: actions/cache@v1
+      with:
+        path: ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle-wrapper.properties') }}
+    - name: Gradle Dependencies Cache
+      uses: actions/cache@v1
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-cache-${{ hashFiles('**/*.gradle') }}
+    - name: Gradle Test
+      run: |
+        ./gradlew -Djava.security.egd=file:/dev/./urandom -Dorg.gradle.console=plain --no-daemon -PverboseTests=true check

--- a/src/main/java/com/adaptris/core/json/jdbc/InsertJsonArray.java
+++ b/src/main/java/com/adaptris/core/json/jdbc/InsertJsonArray.java
@@ -1,15 +1,12 @@
 package com.adaptris.core.json.jdbc;
 
 import java.sql.Connection;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.json.JsonUtil;
-import com.adaptris.core.services.splitter.json.LargeJsonArraySplitter;
 import com.adaptris.core.util.CloseableIterable;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.JdbcUtil;
@@ -50,7 +47,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @ComponentProfile(summary = "Insert a JSON array into a database", tag = "service,json,jdbc", since = "3.6.5")
 @XStreamAlias("json-array-jdbc-insert")
 @DisplayOrder(order = {"table"})
-public class InsertJsonArray extends InsertJsonObject {
+public class InsertJsonArray extends InsertJsonObjects {
 
   public InsertJsonArray() {
 
@@ -63,10 +60,7 @@ public class InsertJsonArray extends InsertJsonObject {
     try {
       log.trace("Beginning doService in {}", LoggingHelper.friendlyName(this));
       conn = getConnection(msg);
-      // Use the already existing LargeJsonArraySplitter, but force it with a default-mf
-      LargeJsonArraySplitter splitter =
-          new LargeJsonArraySplitter().withMessageFactory(AdaptrisMessageFactory.getDefaultInstance());
-      try (CloseableIterable<AdaptrisMessage> itr = splitter.splitMessage(msg)) {
+      try (CloseableIterable<AdaptrisMessage> itr = jsonStyle().createIterator(msg)) {
         for (AdaptrisMessage m : itr) {
           rowsAffected += handleInsert(table(msg), conn, JsonUtil.mapifyJson(m, getNullConverter()));
         }

--- a/src/main/java/com/adaptris/core/json/jdbc/InsertJsonObjects.java
+++ b/src/main/java/com/adaptris/core/json/jdbc/InsertJsonObjects.java
@@ -16,6 +16,11 @@ public abstract class InsertJsonObjects extends InsertJsonObject {
     super();
   }
 
+  public <T extends InsertJsonObjects> T withJsonStyle(JsonStyle p) {
+    setJsonStyle(p);
+    return (T) this;
+  }
+
   /**
    * Specify how the payload is parsed to provide JSON objects.
    * 

--- a/src/main/java/com/adaptris/core/json/jdbc/InsertJsonObjects.java
+++ b/src/main/java/com/adaptris/core/json/jdbc/InsertJsonObjects.java
@@ -1,0 +1,36 @@
+package com.adaptris.core.json.jdbc;
+
+import org.apache.commons.lang3.ObjectUtils;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.services.splitter.json.JsonProvider.JsonStyle;
+
+public abstract class InsertJsonObjects extends InsertJsonObject {
+
+  @AdvancedConfig
+  @InputFieldDefault(value = "JSON_ARRAY")
+  private JsonStyle jsonStyle;
+
+
+  public InsertJsonObjects() {
+    super();
+  }
+
+  /**
+   * Specify how the payload is parsed to provide JSON objects.
+   * 
+   * @param p the provider; default is JSON_ARRAY.
+   */
+  public void setJsonStyle(JsonStyle p) {
+    jsonStyle = p;
+  }
+
+  public JsonStyle getJsonStyle() {
+    return jsonStyle;
+  }
+
+  protected JsonStyle jsonStyle() {
+    return ObjectUtils.defaultIfNull(getJsonStyle(), JsonStyle.JSON_ARRAY);
+  }
+
+}

--- a/src/main/java/com/adaptris/core/json/jdbc/UpsertJsonArray.java
+++ b/src/main/java/com/adaptris/core/json/jdbc/UpsertJsonArray.java
@@ -1,15 +1,12 @@
 package com.adaptris.core.json.jdbc;
 
 import java.sql.Connection;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.json.JsonUtil;
-import com.adaptris.core.services.splitter.json.LargeJsonArraySplitter;
 import com.adaptris.core.util.CloseableIterable;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.JdbcUtil;
@@ -40,7 +37,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @ComponentProfile(summary = "Insert/Update a JSON Array into a database", tag = "service,json,jdbc", since = "3.6.5")
 @XStreamAlias("json-array-jdbc-upsert")
 @DisplayOrder(order = {"table", "idField"})
-public class UpsertJsonArray extends UpsertJsonObject {
+public class UpsertJsonArray extends UpsertJsonObjects {
 
   public UpsertJsonArray() {
 
@@ -53,11 +50,8 @@ public class UpsertJsonArray extends UpsertJsonObject {
     try {
       log.trace("Beginning doService in {}", LoggingHelper.friendlyName(this));
       conn = getConnection(msg);
-      // Use the already existing LargeJsonArraySplitter, but force it with a default-mf
-      LargeJsonArraySplitter splitter =
-          new LargeJsonArraySplitter().withMessageFactory(AdaptrisMessageFactory.getDefaultInstance());
-      try (CloseableIterable<AdaptrisMessage> itr = splitter.splitMessage(msg)) {
-        for (AdaptrisMessage m : splitter.splitMessage(msg)) {
+      try (CloseableIterable<AdaptrisMessage> itr = jsonStyle().createIterator(msg)) {
+        for (AdaptrisMessage m : itr) {
           rowsAffected += handleUpsert(table(msg), conn, JsonUtil.mapifyJson(m, getNullConverter()));
         }
       }

--- a/src/main/java/com/adaptris/core/json/jdbc/UpsertJsonObjects.java
+++ b/src/main/java/com/adaptris/core/json/jdbc/UpsertJsonObjects.java
@@ -16,6 +16,11 @@ public abstract class UpsertJsonObjects extends UpsertJsonObject {
     super();
   }
 
+  public <T extends UpsertJsonObjects> T withJsonStyle(JsonStyle p) {
+    setJsonStyle(p);
+    return (T) this;
+  }
+
   /**
    * Specify how the payload is parsed to provide JSON objects.
    * 

--- a/src/main/java/com/adaptris/core/json/jdbc/UpsertJsonObjects.java
+++ b/src/main/java/com/adaptris/core/json/jdbc/UpsertJsonObjects.java
@@ -1,0 +1,36 @@
+package com.adaptris.core.json.jdbc;
+
+import org.apache.commons.lang3.ObjectUtils;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.services.splitter.json.JsonProvider.JsonStyle;
+
+public abstract class UpsertJsonObjects extends UpsertJsonObject {
+
+  @AdvancedConfig
+  @InputFieldDefault(value = "JSON_ARRAY")
+  private JsonStyle jsonStyle;
+
+
+  public UpsertJsonObjects() {
+    super();
+  }
+
+  /**
+   * Specify how the payload is parsed to provide JSON objects.
+   * 
+   * @param p the provider; default is JSON_ARRAY.
+   */
+  public void setJsonStyle(JsonStyle p) {
+    jsonStyle = p;
+  }
+
+  public JsonStyle getJsonStyle() {
+    return jsonStyle;
+  }
+
+  protected JsonStyle jsonStyle() {
+    return ObjectUtils.defaultIfNull(getJsonStyle(), JsonStyle.JSON_ARRAY);
+  }
+
+}

--- a/src/main/java/com/adaptris/core/services/splitter/json/JsonProvider.java
+++ b/src/main/java/com/adaptris/core/services/splitter/json/JsonProvider.java
@@ -1,0 +1,45 @@
+package com.adaptris.core.services.splitter.json;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.services.splitter.LineCountSplitter;
+import com.adaptris.core.util.CloseableIterable;
+
+/**
+ * Allows switching between JSON arrays and JSON lines when attempting to split a payload.
+ * <p>
+ * This is generally used by services that want to operate on individual JSON objects, and want to be able to switch between JSON
+ * arrays and JSON lines.
+ * </p>
+ */
+public interface JsonProvider {
+
+  enum JsonStyle implements JsonObjectProvider {
+    JSON_ARRAY {
+      @Override
+      public CloseableIterable<AdaptrisMessage> createIterator(AdaptrisMessage t) throws Exception {
+        LargeJsonArraySplitter splitter =
+            new LargeJsonArraySplitter().withMessageFactory(AdaptrisMessageFactory.getDefaultInstance());
+        return splitter.splitMessage(t);
+      }
+    },
+
+    // JSON_LINES is basically a line count splitter, where a JSON object is prsent on each line...
+    // see jsonlines.org
+    JSON_LINES {
+      @Override
+      public CloseableIterable<AdaptrisMessage> createIterator(AdaptrisMessage t) throws Exception {
+        LineCountSplitter splitter = new LineCountSplitter(1);
+        splitter.setIgnoreBlankLines(true);
+        splitter.setMessageFactory(AdaptrisMessageFactory.getDefaultInstance());
+        return splitter.splitMessage(t);
+      }
+    }
+  }
+
+  // Could have been Function<AdaptrisMessage, CloseableIterable<AdaptrisMessage>> but that means we can't
+  // throw exceptions, or we have to wrap things as RTE, or we @SneakyThrows it...
+  public interface JsonObjectProvider {
+    CloseableIterable<AdaptrisMessage> createIterator(AdaptrisMessage t) throws Exception;
+  }
+}

--- a/src/test/java/com/adaptris/core/json/jdbc/InsertJsonArrayTest.java
+++ b/src/test/java/com/adaptris/core/json/jdbc/InsertJsonArrayTest.java
@@ -3,6 +3,7 @@ package com.adaptris.core.json.jdbc;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ServiceException;
+import com.adaptris.core.services.splitter.json.JsonProvider.JsonStyle;
 
 public class InsertJsonArrayTest extends JdbcJsonInsertCase {
 
@@ -47,7 +48,7 @@ public class InsertJsonArrayTest extends JdbcJsonInsertCase {
 
   @Override
   protected InsertJsonArray createService() {
-    return new InsertJsonArray();
+    return new InsertJsonArray().withJsonStyle(JsonStyle.JSON_ARRAY);
   }
 
 }

--- a/src/test/java/com/adaptris/core/json/jdbc/UpsertJsonArrayTest.java
+++ b/src/test/java/com/adaptris/core/json/jdbc/UpsertJsonArrayTest.java
@@ -4,6 +4,7 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.services.jdbc.JdbcMapUpsert;
+import com.adaptris.core.services.splitter.json.JsonProvider.JsonStyle;
 
 public class UpsertJsonArrayTest extends UpsertJsonCase {
 
@@ -19,7 +20,7 @@ public class UpsertJsonArrayTest extends UpsertJsonCase {
 
   @Override
   protected UpsertJsonArray createService() {
-    return new UpsertJsonArray();
+    return new UpsertJsonArray().withJsonStyle(JsonStyle.JSON_ARRAY);
   }
 
   public void testService_InsertArray() throws Exception {

--- a/src/test/java/com/adaptris/core/services/splitter/json/JsonProviderTest.java
+++ b/src/test/java/com/adaptris/core/services/splitter/json/JsonProviderTest.java
@@ -1,0 +1,48 @@
+package com.adaptris.core.services.splitter.json;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.util.Map;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.json.JsonUtil;
+import com.adaptris.core.util.CloseableIterable;
+
+public class JsonProviderTest {
+
+  private static final String LINES = "{\"key\":\"value\"}\r\n\r\n{\"key\":\"value\"}\r\n";
+  private static final String ARRAY = "[{\"key\":\"value\"}, {\"key\":\"value\"}]";
+
+  @Test
+  public void testJsonLines() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(LINES);
+    try (CloseableIterable<AdaptrisMessage> itr = JsonProvider.JsonStyle.JSON_LINES.createIterator(msg)) {
+      int count = 0;
+      for (AdaptrisMessage m : itr) {
+        count++;
+        Map<String, String> map = JsonUtil.mapifyJson(m);
+        assertEquals(1, map.size());
+        assertTrue(map.containsKey("key"));
+      }
+      assertEquals(2, count);
+    }
+  }
+
+
+  @Test
+  public void testJsonArray() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(ARRAY);
+    try (CloseableIterable<AdaptrisMessage> itr = JsonProvider.JsonStyle.JSON_ARRAY.createIterator(msg)) {
+      int count = 0;
+      for (AdaptrisMessage m : itr) {
+        count++;
+        Map<String, String> map = JsonUtil.mapifyJson(m);
+        assertEquals(1, map.size());
+        assertTrue(map.containsKey("key"));
+      }
+      assertEquals(2, count);
+    }
+  }
+
+}


### PR DESCRIPTION
Add a JsonProvider interface that contains a couple of enums that allow us to switch between JSON_LINES and JSON_ARRAY.

- json.jdbc.* now uses the JsonProvider where it prevviously just used the large-array-splitter
- json-to-csv can use this.
- However, the elastic ones are tricksy since they parse the JSON directly themslves; so this might have a larger scope of impact.