### PR TITLE
INTERLOK-3205 Add NullConverter to JsonPathService

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ bin
 out
 .gradle
 gradle.properties
+debug.log

--- a/src/main/java/com/adaptris/core/json/JsonPathExecution.java
+++ b/src/main/java/com/adaptris/core/json/JsonPathExecution.java
@@ -1,52 +1,92 @@
 package com.adaptris.core.json;
 
+import javax.validation.Valid;
 import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.common.Execution;
 import com.adaptris.interlok.config.DataInputParameter;
 import com.adaptris.interlok.config.DataOutputParameter;
+import com.adaptris.util.text.NullConverter;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 @XStreamAlias("json-path-execution")
 @ComponentProfile(summary = "Extract a JSON Path from the source and write it into the target", tag = "json")
-public class JsonPathExecution extends Execution
-{
-	@InputFieldDefault(value = "false")
-	@AdvancedConfig
-	private Boolean suppressPathNotFound;
+public class JsonPathExecution extends Execution {
 
-	public JsonPathExecution()
-	{
-		super();
-	}
+  private static NullConverter NULL_TO_NULL_CONSTANT_STRING = new NullConverter() {
+    @Override
+    public <T> T convert(T t) {
+      return (T) ObjectUtils.defaultIfNull(t, "null");
+    }
+  };
 
-	public JsonPathExecution(DataInputParameter<String> source, DataOutputParameter<String> target)
-	{
-		super(source, target);
-	}
+  @InputFieldDefault(value = "false")
+  @AdvancedConfig
+  private Boolean suppressPathNotFound;
 
-	/**
-	 * @return true or false.
-	 */
-	public Boolean getSuppressPathNotFound()
-	{
-		return suppressPathNotFound;
-	}
+  @Valid
+  @AdvancedConfig
+  private NullConverter nullConverter;
 
-	/**
-	 * Suppress exceptions caused by {@code PathNotFoundException}.
-	 *
-	 * @param b to suppress exceptions arising from a json path not being found; default is null (false).
-	 */
-	public void setSuppressPathNotFound(Boolean b)
-	{
-		this.suppressPathNotFound = b;
-	}
+  public JsonPathExecution() {
+    super();
+  }
 
-	public boolean suppressPathNotFound()
-  {
+  public JsonPathExecution(DataInputParameter<String> source, DataOutputParameter<String> target) {
+    super(source, target);
+  }
+
+  /**
+   * @return true or false.
+   */
+  public Boolean getSuppressPathNotFound() {
+    return suppressPathNotFound;
+  }
+
+  /**
+   * Suppress exceptions caused by {@code PathNotFoundException}.
+   *
+   * @param b to suppress exceptions arising from a json path not being found; default is null (false).
+   */
+  public void setSuppressPathNotFound(Boolean b) {
+    this.suppressPathNotFound = b;
+  }
+
+  public boolean suppressPathNotFound() {
     return BooleanUtils.toBooleanDefaultIfNull(getSuppressPathNotFound(), false);
-	}
+  }
+
+  /**
+   * @return the nullConverter
+   */
+  public NullConverter getNullConverter() {
+    return nullConverter;
+  }
+
+  /**
+   * Specify the behaviour when a null is encountered during json path execution.
+   * 
+   * @param nc the NullConverter to set, the default is return "null" as the value.
+   */
+  public void setNullConverter(NullConverter nc) {
+    this.nullConverter = nc;
+  }
+
+  public NullConverter nullConverter() {
+    return ObjectUtils.defaultIfNull(getNullConverter(), NULL_TO_NULL_CONSTANT_STRING);
+  }
+
+  public <T extends JsonPathExecution> T withNullConverter(NullConverter nc) {
+    setNullConverter(nc);
+    return (T) this;
+  }
+
+  public <T extends JsonPathExecution> T withSuppressPathNotFound(Boolean b) {
+    setSuppressPathNotFound(b);
+    return (T) this;
+  }
+
 }


### PR DESCRIPTION
## Motivation

If you have the document 
```
{
    "LastModifiedDate": "2017-11-23T15:15:31.000+0000",
    "WhatId": null,
    "Description": "wanted more info on ebusiness and agility including analytical models"
}
```

And you use json-path-service to extract `$.WhatId`'; it returns you a null object (correctly, since it is). You can't suppress it, because the path is found... Subsequently we  call null.toString() which causes a NullPointerException and the service fails.

We can work around this by having continue-on-fail etc; but that still leaves you with metadata that needs to be defaulted.

## Modification

Add a null-converter to `json-path-execution` which is then used at execution time by json-path-service. 

The default behaviour is to turn nulls into the string "null". This seems a reasonable default (but note that this is a change of behaviour).

## Result

This is a functional behavioural change to the users expectation... To preserve backwards compatibility we could opt to make the default null-converter = "NullsNotSupportedConverter" which would have the same result as before.

## Testing

Use the above document; with the above json-path; the end result will be (if you're writing to a metadata-key) will be "metadata-key"="null".

