### PR TITLE
feature/INTERLOK-3371

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ plugins {
   id 'nebula.optional-base' version '5.0.3'
   id 'com.github.spotbugs' version '4.4.4'
   id 'org.owasp.dependencycheck' version '5.3.2.1'
+  id "io.freefair.lombok" version "5.1.0"
 }
 
 ext {
@@ -22,6 +23,7 @@ ext {
   repoPassword = project.hasProperty('repoPassword') ? project.getProperty('repoPassword') : 'unknown'
   defaultNexusRepo = project.hasProperty('defaultNexusRepo') ? project.getProperty('defaultNexusRepo') : 'https://repo1.maven.org/maven2/'
   offlineJavadocPackageDir = new File(project.buildDir, "offline-javadoc-packages")
+  delombokTargetDir = new File("${project.projectDir}/src/main/generated")
 
   interlokJavadocs= project.hasProperty('interlokJavadocs') ? project.getProperty('interlokJavadocs') : javadocsBaseUrl + "/interlok-core/" + interlokCoreVersion
   interlokCommonJavadocs= project.hasProperty('interlokCommonJavadocs') ? project.getProperty('interlokCommonJavadocs') : javadocsBaseUrl + "/interlok-common/" + interlokCoreVersion
@@ -93,6 +95,7 @@ sourceCompatibility = 1.8
 group   = 'com.adaptris'
 version = releaseVersion
 def versionDir = "$buildDir/version"
+generateLombokConfig.enabled = false
 
 repositories {
   mavenCentral()
@@ -101,7 +104,6 @@ repositories {
   maven { url "$nexusBaseUrl/content/groups/interlok" }
   maven { url 'https://jitpack.io' }
 }
-
 
 configurations {
   javadoc {}
@@ -154,6 +156,11 @@ dependencies {
   compile ("com.google.guava:guava:29.0-jre")
   compile ("com.flipkart.zjsonpatch:zjsonpatch:0.4.11")
 
+  compile 'io.jsonwebtoken:jjwt-api:0.11.2'
+  runtime 'io.jsonwebtoken:jjwt-impl:0.11.2'
+  runtime 'org.bouncycastle:bcprov-jdk15on:1.60'
+  runtime 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+
   annotationProcessor ("com.adaptris:interlok-core-apt:$interlokCoreVersion") {changing= true}
   umlDoclet("nl.talsmasoftware:umldoclet:1.1.4")
 
@@ -174,9 +181,7 @@ dependencies {
   testCompile ("org.mockito:mockito-inline:$mockitoVersion")
 
   javadoc("com.adaptris:interlok-core-apt:$interlokCoreVersion") { changing= true}
-
 }
-
 
 jar {
   manifest {
@@ -188,7 +193,6 @@ jar {
                "Implementation-Vendor": organizationName)
   }
 }
-
 
 sourceSets {
   main {
@@ -223,8 +227,6 @@ task offlinePackageList(type: Copy) {
   include "package-list"
   into offlineJavadocPackageDir
 }
-
-
 
 javadoc {
   onlyIf {
@@ -265,13 +267,12 @@ task buildUnitTestProperties(type: Copy) {
 
 task deleteGeneratedFiles(type: Delete) {
   delete file(testResourcesDir() + "/unit-tests.properties")
+  delete delombokTargetDir
 }
-
 
 task deleteDerbyLog(type: Delete) {
   delete 'derby.log'
 }
-
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
   classifier = 'javadoc'
@@ -285,7 +286,6 @@ task examplesJar(type: Jar, dependsOn: test) {
 
 task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'
-    from sourceSets.main.allSource
 }
 
 task umlJavadoc(type: Javadoc) {
@@ -295,7 +295,7 @@ task umlJavadoc(type: Javadoc) {
   onlyIf {
     hasGraphViz()
   }
-  source = sourceSets.main.allJava
+  source = sourceSets.main.extensions.delombokTask
   classpath = project.sourceSets.main.compileClasspath
   configure(options) {
     options.linksOffline(interlokJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-core-$interlokCoreVersion-javadoc.jar")
@@ -325,7 +325,6 @@ task umlJavadoc(type: Javadoc) {
     title= componentName
   }
 }
-
 
 artifacts {
   archives javadocJar
@@ -363,6 +362,19 @@ publishing {
       url mavenPublishUrl
     }
   }
+}
+
+delombok {
+  target = delombokTargetDir
+}
+
+task lgtmCompile(type: JavaCompile, dependsOn: delombok) {
+  group 'Build'
+  description 'Compile for lgtm'
+
+  source = sourceSets.main.extensions.delombokTask
+  destinationDir = sourceSets.main.java.outputDir
+  classpath = project.sourceSets.main.compileClasspath
 }
 
 spotbugsMain {

--- a/src/main/java/com/adaptris/core/jwt/JWTCreator.java
+++ b/src/main/java/com/adaptris/core/jwt/JWTCreator.java
@@ -1,0 +1,149 @@
+package com.adaptris.core.jwt;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.ServiceImp;
+import com.adaptris.util.KeyValuePair;
+import com.adaptris.util.KeyValuePairSet;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import io.jsonwebtoken.JwtBuilder;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.Date;
+import java.util.UUID;
+
+@XStreamAlias("jwt-creator")
+@AdapterComponent
+@ComponentProfile(summary = "Create a JSON Web Token", tag = "jwt,create,json,web,token", since="3.11.1")
+@DisplayOrder(order = { "id", "issuer", "subject", "audience", "issuedAt", "expiration", "notBefore", "secret", "customClaims" })
+public class JWTCreator extends ServiceImp
+{
+	@Getter
+	@Setter
+	@Valid
+	@AdvancedConfig(rare = true)
+	private String id;
+
+	@Getter
+	@Setter
+	@NotNull
+	@Valid
+	@InputFieldHint(expression=true)
+	private String issuer;
+
+	@Getter
+	@Setter
+	@NotNull
+	@Valid
+	@InputFieldHint(expression=true)
+	private String subject;
+
+	@Getter
+	@Setter
+	@NotNull
+	@Valid
+	@InputFieldHint(expression=true)
+	private String audience;
+
+	@Getter
+	@Setter
+	@Valid
+	@AdvancedConfig(rare = true)
+	private Date issuedAt;
+
+	@Getter
+	@Setter
+	@NotNull
+	@Valid
+	private Date expiration;
+
+	@Getter
+	@Setter
+	@NotNull
+	@Valid
+	private Date notBefore;
+
+	@Getter
+	@Setter
+	@NotNull
+	@Valid
+	@InputFieldHint(expression=true)
+	private String secret;
+
+	@Getter
+	@Setter
+	@Valid
+	@AdvancedConfig
+	private KeyValuePairSet customClaims;
+
+	/**
+	 * <p>
+	 * Apply the service to the message.
+	 * </p>
+	 *
+	 * @param message the <code>AdaptrisMessage</code> to process
+	 * @throws ServiceException wrapping any underlying <code>Exception</code>s
+	 */
+	@Override
+	public void doService(AdaptrisMessage message)
+	{
+		JwtBuilder builder = Jwts.builder()
+				.setSubject(message.resolve(subject))
+				.setAudience(message.resolve(audience))
+				.setNotBefore(notBefore)
+				.setIssuer(message.resolve(issuer))
+				.setExpiration(expiration)
+				.setIssuedAt(issuedAt != null ? issuedAt : new Date())
+				.setId(id != null ? id : UUID.randomUUID().toString())
+
+				.signWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode(message.resolve(secret))));
+
+		if (customClaims != null)
+		{
+			for (KeyValuePair claim : customClaims)
+			{
+				builder.claim(claim.getKey(), claim.getValue());
+			}
+		}
+
+		message.setContent(builder.compact(), message.getContentEncoding());
+	}
+
+	/**
+	 * {@inheritDoc}.
+	 */
+	@Override
+	protected void initService()
+	{
+		/* unused */
+	}
+
+	/**
+	 * {@inheritDoc}.
+	 */
+	@Override
+	protected void closeService()
+	{
+		/* unused */
+	}
+
+	/**
+	 * Prepare for initialisation.
+	 */
+	@Override
+	public void prepare()
+	{
+		/* unused */
+	}
+}

--- a/src/main/java/com/adaptris/core/jwt/JWTCreator.java
+++ b/src/main/java/com/adaptris/core/jwt/JWTCreator.java
@@ -29,121 +29,121 @@ import java.util.UUID;
 @DisplayOrder(order = { "id", "issuer", "subject", "audience", "issuedAt", "expiration", "notBefore", "secret", "customClaims" })
 public class JWTCreator extends ServiceImp
 {
-	@Getter
-	@Setter
-	@Valid
-	@AdvancedConfig(rare = true)
-	private String id;
+  @Getter
+  @Setter
+  @Valid
+  @AdvancedConfig(rare = true)
+  private String id;
 
-	@Getter
-	@Setter
-	@NotNull
-	@Valid
-	@InputFieldHint(expression=true)
-	private String issuer;
+  @Getter
+  @Setter
+  @NotNull
+  @Valid
+  @InputFieldHint(expression=true)
+  private String issuer;
 
-	@Getter
-	@Setter
-	@NotNull
-	@Valid
-	@InputFieldHint(expression=true)
-	private String subject;
+  @Getter
+  @Setter
+  @NotNull
+  @Valid
+  @InputFieldHint(expression=true)
+  private String subject;
 
-	@Getter
-	@Setter
-	@NotNull
-	@Valid
-	@InputFieldHint(expression=true)
-	private String audience;
+  @Getter
+  @Setter
+  @NotNull
+  @Valid
+  @InputFieldHint(expression=true)
+  private String audience;
 
-	@Getter
-	@Setter
-	@Valid
-	@AdvancedConfig(rare = true)
-	private Date issuedAt;
+  @Getter
+  @Setter
+  @Valid
+  @AdvancedConfig(rare = true)
+  private Date issuedAt;
 
-	@Getter
-	@Setter
-	@NotNull
-	@Valid
-	private Date expiration;
+  @Getter
+  @Setter
+  @NotNull
+  @Valid
+  private Date expiration;
 
-	@Getter
-	@Setter
-	@NotNull
-	@Valid
-	private Date notBefore;
+  @Getter
+  @Setter
+  @NotNull
+  @Valid
+  private Date notBefore;
 
-	@Getter
-	@Setter
-	@NotNull
-	@Valid
-	@InputFieldHint(expression=true)
-	private String secret;
+  @Getter
+  @Setter
+  @NotNull
+  @Valid
+  @InputFieldHint(expression=true)
+  private String secret;
 
-	@Getter
-	@Setter
-	@Valid
-	@AdvancedConfig
-	private KeyValuePairSet customClaims;
+  @Getter
+  @Setter
+  @Valid
+  @AdvancedConfig
+  private KeyValuePairSet customClaims;
 
-	/**
-	 * <p>
-	 * Apply the service to the message.
-	 * </p>
-	 *
-	 * @param message the <code>AdaptrisMessage</code> to process
-	 * @throws ServiceException wrapping any underlying <code>Exception</code>s
-	 */
-	@Override
-	public void doService(AdaptrisMessage message)
-	{
-		JwtBuilder builder = Jwts.builder()
-				.setSubject(message.resolve(subject))
-				.setAudience(message.resolve(audience))
-				.setNotBefore(notBefore)
-				.setIssuer(message.resolve(issuer))
-				.setExpiration(expiration)
-				.setIssuedAt(issuedAt != null ? issuedAt : new Date())
-				.setId(id != null ? id : UUID.randomUUID().toString())
+  /**
+   * <p>
+   * Apply the service to the message.
+   * </p>
+   *
+   * @param message the <code>AdaptrisMessage</code> to process
+   * @throws ServiceException wrapping any underlying <code>Exception</code>s
+   */
+  @Override
+  public void doService(AdaptrisMessage message)
+  {
+    JwtBuilder builder = Jwts.builder()
+        .setSubject(message.resolve(subject))
+        .setAudience(message.resolve(audience))
+        .setNotBefore(notBefore)
+        .setIssuer(message.resolve(issuer))
+        .setExpiration(expiration)
+        .setIssuedAt(issuedAt != null ? issuedAt : new Date())
+        .setId(id != null ? id : UUID.randomUUID().toString())
 
-				.signWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode(message.resolve(secret))));
+        .signWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode(message.resolve(secret))));
 
-		if (customClaims != null)
-		{
-			for (KeyValuePair claim : customClaims)
-			{
-				builder.claim(claim.getKey(), claim.getValue());
-			}
-		}
+    if (customClaims != null)
+    {
+      for (KeyValuePair claim : customClaims)
+      {
+        builder.claim(claim.getKey(), claim.getValue());
+      }
+    }
 
-		message.setContent(builder.compact(), message.getContentEncoding());
-	}
+    message.setContent(builder.compact(), message.getContentEncoding());
+  }
 
-	/**
-	 * {@inheritDoc}.
-	 */
-	@Override
-	protected void initService()
-	{
-		/* unused */
-	}
+  /**
+   * {@inheritDoc}.
+   */
+  @Override
+  protected void initService()
+  {
+    /* unused */
+  }
 
-	/**
-	 * {@inheritDoc}.
-	 */
-	@Override
-	protected void closeService()
-	{
-		/* unused */
-	}
+  /**
+   * {@inheritDoc}.
+   */
+  @Override
+  protected void closeService()
+  {
+    /* unused */
+  }
 
-	/**
-	 * Prepare for initialisation.
-	 */
-	@Override
-	public void prepare()
-	{
-		/* unused */
-	}
+  /**
+   * Prepare for initialisation.
+   */
+  @Override
+  public void prepare()
+  {
+    /* unused */
+  }
 }

--- a/src/main/java/com/adaptris/core/jwt/JWTDecoder.java
+++ b/src/main/java/com/adaptris/core/jwt/JWTDecoder.java
@@ -55,84 +55,84 @@ import java.util.Map;
 @DisplayOrder(order = { "jwtString", "secret", "header", "claims" })
 public class JWTDecoder extends ServiceImp
 {
-	private static transient Logger log = LoggerFactory.getLogger(JWTDecoder.class);
+  private static transient Logger log = LoggerFactory.getLogger(JWTDecoder.class);
 
-	@NotNull
-	@Valid
-	@Getter
-	@Setter
-	private DataInputParameter<String> jwtString;
+  @NotNull
+  @Valid
+  @Getter
+  @Setter
+  private DataInputParameter<String> jwtString;
 
-	@NotNull
-	@Valid
-	@Getter
-	@Setter
-	private DataInputParameter<String> secret;
+  @NotNull
+  @Valid
+  @Getter
+  @Setter
+  private DataInputParameter<String> secret;
 
-	@NotNull
-	@Valid
-	@Getter
-	@Setter
-	private DataOutputParameter<String> header;
+  @NotNull
+  @Valid
+  @Getter
+  @Setter
+  private DataOutputParameter<String> header;
 
-	@NotNull
-	@Valid
-	@Getter
-	@Setter
-	private DataOutputParameter<String> claims;
+  @NotNull
+  @Valid
+  @Getter
+  @Setter
+  private DataOutputParameter<String> claims;
 
-	/**
-	 * {@inheritDoc}.
-	 */
-	@Override
-	public void doService(AdaptrisMessage message) throws ServiceException
-	{
-		try
-		{
-			String key = secret.extract(message);
-			String jwt = jwtString.extract(message);
+  /**
+   * {@inheritDoc}.
+   */
+  @Override
+  public void doService(AdaptrisMessage message) throws ServiceException
+  {
+    try
+    {
+      String key = secret.extract(message);
+      String jwt = jwtString.extract(message);
 
-			Key k = Keys.hmacShaKeyFor(Decoders.BASE64.decode(key));
+      Key k = Keys.hmacShaKeyFor(Decoders.BASE64.decode(key));
 
-			Jws<Claims> jws = Jwts.parserBuilder().setSigningKey(k).build().parseClaimsJws(jwt);
+      Jws<Claims> jws = Jwts.parserBuilder().setSigningKey(k).build().parseClaimsJws(jwt);
 
-			JSONObject head = new JSONObject(jws.getHeader());
-			header.insert(head.toString(), message);
+      JSONObject head = new JSONObject(jws.getHeader());
+      header.insert(head.toString(), message);
 
-			JSONObject body = new JSONObject(jws.getBody());
-			claims.insert(body.toString(), message);
-		}
-		catch (Exception e)
-		{
-			log.error("An error occurred during JWT decoding", e);
-			throw new ServiceException(e);
-		}
-	}
+      JSONObject body = new JSONObject(jws.getBody());
+      claims.insert(body.toString(), message);
+    }
+    catch (Exception e)
+    {
+      log.error("An error occurred during JWT decoding", e);
+      throw new ServiceException(e);
+    }
+  }
 
-	/**
-	 * {@inheritDoc}.
-	 */
-	@Override
-	protected void initService()
-	{
-		/* unused */
-	}
+  /**
+   * {@inheritDoc}.
+   */
+  @Override
+  protected void initService()
+  {
+    /* unused */
+  }
 
-	/**
-	 * {@inheritDoc}.
-	 */
-	@Override
-	protected void closeService()
-	{
-		/* unused */
-	}
+  /**
+   * {@inheritDoc}.
+   */
+  @Override
+  protected void closeService()
+  {
+    /* unused */
+  }
 
-	/**
-	 * {@inheritDoc}.
-	 */
-	@Override
-	public void prepare()
-	{
-		/* unused */
-	}
+  /**
+   * {@inheritDoc}.
+   */
+  @Override
+  public void prepare()
+  {
+    /* unused */
+  }
 }

--- a/src/main/java/com/adaptris/core/jwt/JWTDecoder.java
+++ b/src/main/java/com/adaptris/core/jwt/JWTDecoder.java
@@ -6,17 +6,11 @@ import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.ServiceImp;
-import com.adaptris.core.common.MetadataStreamInputParameter;
-import com.adaptris.core.common.MetadataStreamOutputParameter;
-import com.adaptris.core.common.PayloadStreamInputParameter;
-import com.adaptris.core.common.PayloadStreamOutputParameter;
-import com.adaptris.core.common.StringPayloadDataInputParameter;
 import com.adaptris.interlok.config.DataInputParameter;
 import com.adaptris.interlok.config.DataOutputParameter;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
-import io.jsonwebtoken.JwsHeader;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
@@ -29,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.security.Key;
-import java.util.Map;
 
 /**
  * This service provides a way to decode a JSON Web Token.

--- a/src/main/java/com/adaptris/core/jwt/JWTDecoder.java
+++ b/src/main/java/com/adaptris/core/jwt/JWTDecoder.java
@@ -1,0 +1,138 @@
+package com.adaptris.core.jwt;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.ServiceImp;
+import com.adaptris.core.common.MetadataStreamInputParameter;
+import com.adaptris.core.common.MetadataStreamOutputParameter;
+import com.adaptris.core.common.PayloadStreamInputParameter;
+import com.adaptris.core.common.PayloadStreamOutputParameter;
+import com.adaptris.core.common.StringPayloadDataInputParameter;
+import com.adaptris.interlok.config.DataInputParameter;
+import com.adaptris.interlok.config.DataOutputParameter;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.Getter;
+import lombok.Setter;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.security.Key;
+import java.util.Map;
+
+/**
+ * This service provides a way to decode a JSON Web Token.
+ *
+ * <pre>{@code
+ *    <jwt-encode>
+ *        <unique-id>mad-lalande</unique-id>
+ *        <secret class="constant-data-input-parameter">
+ *            <value>base64 encoded secret</value>
+ *        </secret>
+ *        <jwt-string class="string-payload-input-parameter"/>  <!-- The Base64 encoded JWT string -->
+ *        <header class="string-payload-output-parameter"/>     <!-- The JSON header -->
+ *        <claims class="string-payload-output-parameter"/>     <!-- The JSON message body -->
+ *    </jwt-encode>
+ * }</pre>
+ *
+ * @author aanderson
+ * @config jwt-decode
+ */
+@XStreamAlias("jwt-decode")
+@AdapterComponent
+@ComponentProfile(summary = "Encode a header and body to a JSON Web Token", tag = "jwt,decode,json,web,token", since="3.11.1")
+@DisplayOrder(order = { "jwtString", "secret", "header", "claims" })
+public class JWTDecoder extends ServiceImp
+{
+	private static transient Logger log = LoggerFactory.getLogger(JWTDecoder.class);
+
+	@NotNull
+	@Valid
+	@Getter
+	@Setter
+	private DataInputParameter<String> jwtString;
+
+	@NotNull
+	@Valid
+	@Getter
+	@Setter
+	private DataInputParameter<String> secret;
+
+	@NotNull
+	@Valid
+	@Getter
+	@Setter
+	private DataOutputParameter<String> header;
+
+	@NotNull
+	@Valid
+	@Getter
+	@Setter
+	private DataOutputParameter<String> claims;
+
+	/**
+	 * {@inheritDoc}.
+	 */
+	@Override
+	public void doService(AdaptrisMessage message) throws ServiceException
+	{
+		try
+		{
+			String key = secret.extract(message);
+			String jwt = jwtString.extract(message);
+
+			Key k = Keys.hmacShaKeyFor(Decoders.BASE64.decode(key));
+
+			Jws<Claims> jws = Jwts.parserBuilder().setSigningKey(k).build().parseClaimsJws(jwt);
+
+			JSONObject head = new JSONObject(jws.getHeader());
+			header.insert(head.toString(), message);
+
+			JSONObject body = new JSONObject(jws.getBody());
+			claims.insert(body.toString(), message);
+		}
+		catch (Exception e)
+		{
+			log.error("An error occurred during JWT decoding", e);
+			throw new ServiceException(e);
+		}
+	}
+
+	/**
+	 * {@inheritDoc}.
+	 */
+	@Override
+	protected void initService()
+	{
+		/* unused */
+	}
+
+	/**
+	 * {@inheritDoc}.
+	 */
+	@Override
+	protected void closeService()
+	{
+		/* unused */
+	}
+
+	/**
+	 * {@inheritDoc}.
+	 */
+	@Override
+	public void prepare()
+	{
+		/* unused */
+	}
+}

--- a/src/main/java/com/adaptris/core/jwt/JWTEncoder.java
+++ b/src/main/java/com/adaptris/core/jwt/JWTEncoder.java
@@ -59,113 +59,113 @@ import java.util.Map;
 @DisplayOrder(order = { "header", "claims", "secret", "generateKey", "keyOutput", "jwtOutput" })
 public class JWTEncoder extends ServiceImp
 {
-	private static transient Logger log = LoggerFactory.getLogger(JWTEncoder.class);
+  private static transient Logger log = LoggerFactory.getLogger(JWTEncoder.class);
 
-	@NotNull
-	@Valid
-	@Getter
-	@Setter
-	private DataInputParameter<String> header;
+  @NotNull
+  @Valid
+  @Getter
+  @Setter
+  private DataInputParameter<String> header;
 
-	@NotNull
-	@Valid
-	@Getter
-	@Setter
-	private DataInputParameter<String> claims;
+  @NotNull
+  @Valid
+  @Getter
+  @Setter
+  private DataInputParameter<String> claims;
 
-	@NotNull
-	@Valid
-	@Getter
-	@Setter
-	private DataInputParameter<String> secret;
+  @NotNull
+  @Valid
+  @Getter
+  @Setter
+  private DataInputParameter<String> secret;
 
-	@Valid
-	@AdvancedConfig
-	@InputFieldDefault(value = "false")
-	@Getter
-	@Setter
-	private Boolean generateKey;
+  @Valid
+  @AdvancedConfig
+  @InputFieldDefault(value = "false")
+  @Getter
+  @Setter
+  private Boolean generateKey;
 
-	@Valid
-	@AdvancedConfig
-	@Getter
-	@Setter
-	private DataOutputParameter<String> keyOutput;
+  @Valid
+  @AdvancedConfig
+  @Getter
+  @Setter
+  private DataOutputParameter<String> keyOutput;
 
-	@NotNull
-	@Valid
-	@Getter
-	@Setter
-	private DataOutputParameter<String> jwtOutput;
+  @NotNull
+  @Valid
+  @Getter
+  @Setter
+  private DataOutputParameter<String> jwtOutput;
 
-	/**
-	 * {@inheritDoc}.
-	 */
-	@Override
-	public void doService(AdaptrisMessage message) throws ServiceException
-	{
-		try
-		{
-			// might as well ensure we've got valid JSON
-			JSONObject head = new JSONObject(header.extract(message));
-			JSONObject body = new JSONObject(claims.extract(message));
-			String key = secret.extract(message);
+  /**
+   * {@inheritDoc}.
+   */
+  @Override
+  public void doService(AdaptrisMessage message) throws ServiceException
+  {
+    try
+    {
+      // might as well ensure we've got valid JSON
+      JSONObject head = new JSONObject(header.extract(message));
+      JSONObject body = new JSONObject(claims.extract(message));
+      String key = secret.extract(message);
 
-			Key k;
-			if (generateKey())
-			{
-				k = Keys.secretKeyFor(SignatureAlgorithm.forName(head.getString(JwsHeader.ALGORITHM)));
-				if (keyOutput == null)
-				{
-					throw new InvalidParameterException("Key Output cannot be NULL");
-				}
-				keyOutput.insert(Encoders.BASE64.encode(k.getEncoded()), message);
-			}
-			else
-			{
-				k = Keys.hmacShaKeyFor(Decoders.BASE64.decode(key));
-			}
+      Key k;
+      if (generateKey())
+      {
+        k = Keys.secretKeyFor(SignatureAlgorithm.forName(head.getString(JwsHeader.ALGORITHM)));
+        if (keyOutput == null)
+        {
+          throw new InvalidParameterException("Key Output cannot be NULL");
+        }
+        keyOutput.insert(Encoders.BASE64.encode(k.getEncoded()), message);
+      }
+      else
+      {
+        k = Keys.hmacShaKeyFor(Decoders.BASE64.decode(key));
+      }
 
-			String jwt = Jwts.builder().setClaims(body.toMap()).setHeader(head.toMap()).signWith(k).compact();
+      String jwt = Jwts.builder().setClaims(body.toMap()).setHeader(head.toMap()).signWith(k).compact();
 
-			jwtOutput.insert(jwt, message);
-		}
-		catch (Exception e)
-		{
-			log.error("An error occurred during JWT encoding", e);
-			throw new ServiceException(e);
-		}
-	}
+      jwtOutput.insert(jwt, message);
+    }
+    catch (Exception e)
+    {
+      log.error("An error occurred during JWT encoding", e);
+      throw new ServiceException(e);
+    }
+  }
 
-	private boolean generateKey()
-	{
-		return BooleanUtils.toBooleanDefaultIfNull(generateKey, false);
-	}
+  private boolean generateKey()
+  {
+    return BooleanUtils.toBooleanDefaultIfNull(generateKey, false);
+  }
 
-	/**
-	 * {@inheritDoc}.
-	 */
-	@Override
-	protected void initService()
-	{
-		/* unused */
-	}
+  /**
+   * {@inheritDoc}.
+   */
+  @Override
+  protected void initService()
+  {
+    /* unused */
+  }
 
-	/**
-	 * {@inheritDoc}.
-	 */
-	@Override
-	protected void closeService()
-	{
-		/* unused */
-	}
+  /**
+   * {@inheritDoc}.
+   */
+  @Override
+  protected void closeService()
+  {
+    /* unused */
+  }
 
-	/**
-	 * {@inheritDoc}.
-	 */
-	@Override
-	public void prepare()
-	{
-		/* unused */
-	}
+  /**
+   * {@inheritDoc}.
+   */
+  @Override
+  public void prepare()
+  {
+    /* unused */
+  }
 }

--- a/src/main/java/com/adaptris/core/jwt/JWTEncoder.java
+++ b/src/main/java/com/adaptris/core/jwt/JWTEncoder.java
@@ -1,0 +1,171 @@
+package com.adaptris.core.jwt;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.ServiceImp;
+import com.adaptris.interlok.config.DataInputParameter;
+import com.adaptris.interlok.config.DataOutputParameter;
+import com.adaptris.interlok.util.Args;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.io.Encoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.BooleanUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.groups.Default;
+import java.security.InvalidParameterException;
+import java.security.Key;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This service provides a way to encode data as a JSON Web Token.
+ *
+ * <pre>{@code
+ *    <jwt-encode>
+ *        <unique-id>mad-lalande</unique-id>
+ *        <secret class="constant-data-input-parameter">
+ *            <value>base64 encoded secret</value>
+ *        </secret>
+ *        <header class="string-payload-input-parameter"/>      <!-- The JSON header -->
+ *        <claims class="string-payload-input-parameter"/>      <!-- The JSON message body -->
+ *        <jwt-output class="string-payload-output-parameter"/> <!-- The base64 encoded JWT string -->
+ *    </jwt-encode>
+ * }</pre>
+ *
+ * @author aanderson
+ * @config jwt-encode
+ */
+@XStreamAlias("jwt-encode")
+@AdapterComponent
+@ComponentProfile(summary = "Encode a header and body to a JSON Web Token", tag = "jwt,encode,json,web,token", since="3.11.1")
+@DisplayOrder(order = { "header", "claims", "secret", "generateKey", "keyOutput", "jwtOutput" })
+public class JWTEncoder extends ServiceImp
+{
+	private static transient Logger log = LoggerFactory.getLogger(JWTEncoder.class);
+
+	@NotNull
+	@Valid
+	@Getter
+	@Setter
+	private DataInputParameter<String> header;
+
+	@NotNull
+	@Valid
+	@Getter
+	@Setter
+	private DataInputParameter<String> claims;
+
+	@NotNull
+	@Valid
+	@Getter
+	@Setter
+	private DataInputParameter<String> secret;
+
+	@Valid
+	@AdvancedConfig
+	@InputFieldDefault(value = "false")
+	@Getter
+	@Setter
+	private Boolean generateKey;
+
+	@Valid
+	@AdvancedConfig
+	@Getter
+	@Setter
+	private DataOutputParameter<String> keyOutput;
+
+	@NotNull
+	@Valid
+	@Getter
+	@Setter
+	private DataOutputParameter<String> jwtOutput;
+
+	/**
+	 * {@inheritDoc}.
+	 */
+	@Override
+	public void doService(AdaptrisMessage message) throws ServiceException
+	{
+		try
+		{
+			// might as well ensure we've got valid JSON
+			JSONObject head = new JSONObject(header.extract(message));
+			JSONObject body = new JSONObject(claims.extract(message));
+			String key = secret.extract(message);
+
+			Key k;
+			if (generateKey())
+			{
+				k = Keys.secretKeyFor(SignatureAlgorithm.forName(head.getString(JwsHeader.ALGORITHM)));
+				if (keyOutput == null)
+				{
+					throw new InvalidParameterException("Key Output cannot be NULL");
+				}
+				keyOutput.insert(Encoders.BASE64.encode(k.getEncoded()), message);
+			}
+			else
+			{
+				k = Keys.hmacShaKeyFor(Decoders.BASE64.decode(key));
+			}
+
+			String jwt = Jwts.builder().setClaims(body.toMap()).setHeader(head.toMap()).signWith(k).compact();
+
+			jwtOutput.insert(jwt, message);
+		}
+		catch (Exception e)
+		{
+			log.error("An error occurred during JWT encoding", e);
+			throw new ServiceException(e);
+		}
+	}
+
+	private boolean generateKey()
+	{
+		return BooleanUtils.toBooleanDefaultIfNull(generateKey, false);
+	}
+
+	/**
+	 * {@inheritDoc}.
+	 */
+	@Override
+	protected void initService()
+	{
+		/* unused */
+	}
+
+	/**
+	 * {@inheritDoc}.
+	 */
+	@Override
+	protected void closeService()
+	{
+		/* unused */
+	}
+
+	/**
+	 * {@inheritDoc}.
+	 */
+	@Override
+	public void prepare()
+	{
+		/* unused */
+	}
+}

--- a/src/main/java/com/adaptris/core/jwt/JWTEncoder.java
+++ b/src/main/java/com/adaptris/core/jwt/JWTEncoder.java
@@ -10,9 +10,7 @@ import com.adaptris.core.ServiceException;
 import com.adaptris.core.ServiceImp;
 import com.adaptris.interlok.config.DataInputParameter;
 import com.adaptris.interlok.config.DataOutputParameter;
-import com.adaptris.interlok.util.Args;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-import io.jsonwebtoken.Header;
 import io.jsonwebtoken.JwsHeader;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -22,18 +20,14 @@ import io.jsonwebtoken.security.Keys;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.BooleanUtils;
-import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import javax.validation.groups.Default;
 import java.security.InvalidParameterException;
 import java.security.Key;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * This service provides a way to encode data as a JSON Web Token.

--- a/src/test/java/com/adaptris/core/jwt/JWTCommonTest.java
+++ b/src/test/java/com/adaptris/core/jwt/JWTCommonTest.java
@@ -9,16 +9,22 @@ import java.nio.charset.Charset;
 
 public abstract class JWTCommonTest extends ServiceCase
 {
-  protected static final String JWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.hhEuJw4rM6XeYHesiLj_RNR-ONRQp34XgwDZIEp5hFLYiXRB8PDvMaZPyAcq9u3_QwWbMthvQU7yORuKOesoHQ";
+  protected static final String JWT = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJCb2IiLCJhdWQiOiJ5b3UiLCJuYmYiOjE1Nzc4MzY4MDAsImlzcyI6Im1lIiwiZXhwIjoyMjQwNTI0ODAwLCJpYXQiOjE1Nzc4MzY4MDAsImp0aSI6IjRmMDQ0MzIyLTVkYjMtNDRkMi1hNjk4LTE1Yjc1NGJkN2EwNSJ9.7BQ0AQLS3_2ywUAtRHgWjn6UK04yvRRi_Epll4hwjuuUw7xKVqDvo-WJlt2s-4MhpAaiHi8sJAuP2ZyOPjmwqQ";
   protected static final String KEY = "lJMnnsrA5PhBnRXE/QnVzoIACiiUMwGNKVVDtvuAcEQR7MMXVFAceSnZPubva1n5xOxPe/O8f0AO3DBHokky3A==";
 
-  protected static final JSONObject HEADER = new JSONObject("{\"alg\":\"HS512\",\"typ\":\"JWT\"}");
-  protected static final JSONObject CLAIMS = new JSONObject("{\"name\":\"John Doe\",\"sub\":\"1234567890\",\"iat\":1516239022}");
+  protected static final JSONObject HEADER = new JSONObject("{\"alg\": \"HS512\"}");
+  protected static final JSONObject CLAIMS = new JSONObject("{\"sub\": \"Bob\", \"aud\": \"you\", \"nbf\": 1577836800, \"iss\": \"me\", \"exp\": 2240524800, \"iat\": 1577836800, \"jti\": \"4f044322-5db3-44d2-a698-15b754bd7a05\"}");
 
   protected AdaptrisMessage message()
   {
     AdaptrisMessage message = DefaultMessageFactory.getDefaultInstance().newMessage();
     message.setContentEncoding(Charset.defaultCharset().name());
     return message;
+  }
+
+  @Override
+  public boolean isAnnotatedForJunit4()
+  {
+    return true;
   }
 }

--- a/src/test/java/com/adaptris/core/jwt/JWTCommonTest.java
+++ b/src/test/java/com/adaptris/core/jwt/JWTCommonTest.java
@@ -9,16 +9,16 @@ import java.nio.charset.Charset;
 
 public abstract class JWTCommonTest extends ServiceCase
 {
-	protected static final String JWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.hhEuJw4rM6XeYHesiLj_RNR-ONRQp34XgwDZIEp5hFLYiXRB8PDvMaZPyAcq9u3_QwWbMthvQU7yORuKOesoHQ";
-	protected static final String KEY = "lJMnnsrA5PhBnRXE/QnVzoIACiiUMwGNKVVDtvuAcEQR7MMXVFAceSnZPubva1n5xOxPe/O8f0AO3DBHokky3A==";
+  protected static final String JWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.hhEuJw4rM6XeYHesiLj_RNR-ONRQp34XgwDZIEp5hFLYiXRB8PDvMaZPyAcq9u3_QwWbMthvQU7yORuKOesoHQ";
+  protected static final String KEY = "lJMnnsrA5PhBnRXE/QnVzoIACiiUMwGNKVVDtvuAcEQR7MMXVFAceSnZPubva1n5xOxPe/O8f0AO3DBHokky3A==";
 
-	protected static final JSONObject HEADER = new JSONObject("{\"alg\":\"HS512\",\"typ\":\"JWT\"}");
-	protected static final JSONObject CLAIMS = new JSONObject("{\"name\":\"John Doe\",\"sub\":\"1234567890\",\"iat\":1516239022}");
+  protected static final JSONObject HEADER = new JSONObject("{\"alg\":\"HS512\",\"typ\":\"JWT\"}");
+  protected static final JSONObject CLAIMS = new JSONObject("{\"name\":\"John Doe\",\"sub\":\"1234567890\",\"iat\":1516239022}");
 
-	protected AdaptrisMessage message()
-	{
-		AdaptrisMessage message = DefaultMessageFactory.getDefaultInstance().newMessage();
-		message.setContentEncoding(Charset.defaultCharset().name());
-		return message;
-	}
+  protected AdaptrisMessage message()
+  {
+    AdaptrisMessage message = DefaultMessageFactory.getDefaultInstance().newMessage();
+    message.setContentEncoding(Charset.defaultCharset().name());
+    return message;
+  }
 }

--- a/src/test/java/com/adaptris/core/jwt/JWTCommonTest.java
+++ b/src/test/java/com/adaptris/core/jwt/JWTCommonTest.java
@@ -1,0 +1,24 @@
+package com.adaptris.core.jwt;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.ServiceCase;
+import org.json.JSONObject;
+
+import java.nio.charset.Charset;
+
+public abstract class JWTCommonTest extends ServiceCase
+{
+	protected static final String JWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.hhEuJw4rM6XeYHesiLj_RNR-ONRQp34XgwDZIEp5hFLYiXRB8PDvMaZPyAcq9u3_QwWbMthvQU7yORuKOesoHQ";
+	protected static final String KEY = "lJMnnsrA5PhBnRXE/QnVzoIACiiUMwGNKVVDtvuAcEQR7MMXVFAceSnZPubva1n5xOxPe/O8f0AO3DBHokky3A==";
+
+	protected static final JSONObject HEADER = new JSONObject("{\"alg\":\"HS512\",\"typ\":\"JWT\"}");
+	protected static final JSONObject CLAIMS = new JSONObject("{\"name\":\"John Doe\",\"sub\":\"1234567890\",\"iat\":1516239022}");
+
+	protected AdaptrisMessage message()
+	{
+		AdaptrisMessage message = DefaultMessageFactory.getDefaultInstance().newMessage();
+		message.setContentEncoding(Charset.defaultCharset().name());
+		return message;
+	}
+}

--- a/src/test/java/com/adaptris/core/jwt/JWTCreatorTest.java
+++ b/src/test/java/com/adaptris/core/jwt/JWTCreatorTest.java
@@ -1,0 +1,91 @@
+package com.adaptris.core.jwt;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.common.ConstantDataInputParameter;
+import com.adaptris.core.common.MetadataDataOutputParameter;
+import com.adaptris.core.common.StringPayloadDataInputParameter;
+import com.adaptris.core.common.StringPayloadDataOutputParameter;
+import com.adaptris.util.KeyValuePair;
+import com.adaptris.util.KeyValuePairSet;
+import io.jsonwebtoken.Claims;
+import lombok.SneakyThrows;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import java.text.SimpleDateFormat;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class JWTCreatorTest extends JWTCommonTest
+{
+	private SimpleDateFormat PARSER = new SimpleDateFormat("yyyy-MM-dd");
+
+	@Test
+	public void testCreate() throws Exception
+	{
+		JWTCreator service = (JWTCreator)retrieveObjectForSampleConfig();
+		service.setId("4f044322-5db3-44d2-a698-15b754bd7a05");
+		service.setIssuedAt(PARSER.parse("2020-01-01"));
+		AdaptrisMessage message = message();
+
+		service.doService(message);
+
+		assertEquals(JWT, message.getContent());
+	}
+
+	@Test
+	public void testCreateClaims() throws Exception
+	{
+		JWTCreator service = (JWTCreator)retrieveObjectForSampleConfig();
+
+		KeyValuePairSet claims = new KeyValuePairSet();
+		claims.addKeyValuePair(new KeyValuePair("custom-claim-1", "value-1"));
+		claims.addKeyValuePair(new KeyValuePair("custom-claim-2", "value-2"));
+		service.setCustomClaims(claims);
+
+		AdaptrisMessage message = message();
+
+		service.doService(message);
+
+		JWTDecoder decoder = new JWTDecoder();
+		decoder.setJwtString(new StringPayloadDataInputParameter());
+		decoder.setSecret(new ConstantDataInputParameter(KEY));
+		decoder.setHeader(new MetadataDataOutputParameter("header"));
+		decoder.setClaims(new StringPayloadDataOutputParameter());
+
+		decoder.doService(message);
+
+		JSONObject json = new JSONObject(message.getContent());
+
+		assertEquals(CLAIMS.get(Claims.SUBJECT), json.get(Claims.SUBJECT));
+		assertEquals(CLAIMS.get(Claims.AUDIENCE), json.get(Claims.AUDIENCE));
+		assertEquals(CLAIMS.get(Claims.ISSUER), json.get(Claims.ISSUER));
+		assertEquals(CLAIMS.get(Claims.EXPIRATION), json.get(Claims.EXPIRATION));
+		assertEquals(CLAIMS.get(Claims.NOT_BEFORE), json.get(Claims.NOT_BEFORE));
+		assertTrue(json.has(Claims.ISSUED_AT));
+		assertTrue(json.has(Claims.ID));
+		assertEquals("value-1", json.getString("custom-claim-1"));
+		assertEquals("value-2", json.getString("custom-claim-2"));
+	}
+
+	@SneakyThrows
+	@Override
+	protected Object retrieveObjectForSampleConfig()
+	{
+		JWTCreator creator = new JWTCreator();
+		creator.setIssuer("me");
+		creator.setSubject("Bob");
+		creator.setAudience("you");
+		creator.setExpiration(PARSER.parse("2040-12-31"));
+		creator.setNotBefore(PARSER.parse("2020-01-01"));
+		creator.setSecret(KEY);
+		return creator;
+	}
+}

--- a/src/test/java/com/adaptris/core/jwt/JWTCreatorTest.java
+++ b/src/test/java/com/adaptris/core/jwt/JWTCreatorTest.java
@@ -1,7 +1,6 @@
 package com.adaptris.core.jwt;
 
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.ServiceException;
 import com.adaptris.core.common.ConstantDataInputParameter;
 import com.adaptris.core.common.MetadataDataOutputParameter;
 import com.adaptris.core.common.StringPayloadDataInputParameter;
@@ -12,16 +11,11 @@ import io.jsonwebtoken.Claims;
 import lombok.SneakyThrows;
 import org.json.JSONObject;
 import org.junit.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.text.SimpleDateFormat;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class JWTCreatorTest extends JWTCommonTest
 {

--- a/src/test/java/com/adaptris/core/jwt/JWTCreatorTest.java
+++ b/src/test/java/com/adaptris/core/jwt/JWTCreatorTest.java
@@ -25,67 +25,67 @@ import static org.junit.Assert.fail;
 
 public class JWTCreatorTest extends JWTCommonTest
 {
-	private SimpleDateFormat PARSER = new SimpleDateFormat("yyyy-MM-dd");
+  private SimpleDateFormat PARSER = new SimpleDateFormat("yyyy-MM-dd");
 
-	@Test
-	public void testCreate() throws Exception
-	{
-		JWTCreator service = (JWTCreator)retrieveObjectForSampleConfig();
-		service.setId("4f044322-5db3-44d2-a698-15b754bd7a05");
-		service.setIssuedAt(PARSER.parse("2020-01-01"));
-		AdaptrisMessage message = message();
+  @Test
+  public void testCreate() throws Exception
+  {
+    JWTCreator service = (JWTCreator)retrieveObjectForSampleConfig();
+    service.setId("4f044322-5db3-44d2-a698-15b754bd7a05");
+    service.setIssuedAt(PARSER.parse("2020-01-01"));
+    AdaptrisMessage message = message();
 
-		service.doService(message);
+    service.doService(message);
 
-		assertEquals(JWT, message.getContent());
-	}
+    assertEquals(JWT, message.getContent());
+  }
 
-	@Test
-	public void testCreateClaims() throws Exception
-	{
-		JWTCreator service = (JWTCreator)retrieveObjectForSampleConfig();
+  @Test
+  public void testCreateClaims() throws Exception
+  {
+    JWTCreator service = (JWTCreator)retrieveObjectForSampleConfig();
 
-		KeyValuePairSet claims = new KeyValuePairSet();
-		claims.addKeyValuePair(new KeyValuePair("custom-claim-1", "value-1"));
-		claims.addKeyValuePair(new KeyValuePair("custom-claim-2", "value-2"));
-		service.setCustomClaims(claims);
+    KeyValuePairSet claims = new KeyValuePairSet();
+    claims.addKeyValuePair(new KeyValuePair("custom-claim-1", "value-1"));
+    claims.addKeyValuePair(new KeyValuePair("custom-claim-2", "value-2"));
+    service.setCustomClaims(claims);
 
-		AdaptrisMessage message = message();
+    AdaptrisMessage message = message();
 
-		service.doService(message);
+    service.doService(message);
 
-		JWTDecoder decoder = new JWTDecoder();
-		decoder.setJwtString(new StringPayloadDataInputParameter());
-		decoder.setSecret(new ConstantDataInputParameter(KEY));
-		decoder.setHeader(new MetadataDataOutputParameter("header"));
-		decoder.setClaims(new StringPayloadDataOutputParameter());
+    JWTDecoder decoder = new JWTDecoder();
+    decoder.setJwtString(new StringPayloadDataInputParameter());
+    decoder.setSecret(new ConstantDataInputParameter(KEY));
+    decoder.setHeader(new MetadataDataOutputParameter("header"));
+    decoder.setClaims(new StringPayloadDataOutputParameter());
 
-		decoder.doService(message);
+    decoder.doService(message);
 
-		JSONObject json = new JSONObject(message.getContent());
+    JSONObject json = new JSONObject(message.getContent());
 
-		assertEquals(CLAIMS.get(Claims.SUBJECT), json.get(Claims.SUBJECT));
-		assertEquals(CLAIMS.get(Claims.AUDIENCE), json.get(Claims.AUDIENCE));
-		assertEquals(CLAIMS.get(Claims.ISSUER), json.get(Claims.ISSUER));
-		assertEquals(CLAIMS.get(Claims.EXPIRATION), json.get(Claims.EXPIRATION));
-		assertEquals(CLAIMS.get(Claims.NOT_BEFORE), json.get(Claims.NOT_BEFORE));
-		assertTrue(json.has(Claims.ISSUED_AT));
-		assertTrue(json.has(Claims.ID));
-		assertEquals("value-1", json.getString("custom-claim-1"));
-		assertEquals("value-2", json.getString("custom-claim-2"));
-	}
+    assertEquals(CLAIMS.get(Claims.SUBJECT), json.get(Claims.SUBJECT));
+    assertEquals(CLAIMS.get(Claims.AUDIENCE), json.get(Claims.AUDIENCE));
+    assertEquals(CLAIMS.get(Claims.ISSUER), json.get(Claims.ISSUER));
+    assertEquals(CLAIMS.get(Claims.EXPIRATION), json.get(Claims.EXPIRATION));
+    assertEquals(CLAIMS.get(Claims.NOT_BEFORE), json.get(Claims.NOT_BEFORE));
+    assertTrue(json.has(Claims.ISSUED_AT));
+    assertTrue(json.has(Claims.ID));
+    assertEquals("value-1", json.getString("custom-claim-1"));
+    assertEquals("value-2", json.getString("custom-claim-2"));
+  }
 
-	@SneakyThrows
-	@Override
-	protected Object retrieveObjectForSampleConfig()
-	{
-		JWTCreator creator = new JWTCreator();
-		creator.setIssuer("me");
-		creator.setSubject("Bob");
-		creator.setAudience("you");
-		creator.setExpiration(PARSER.parse("2040-12-31"));
-		creator.setNotBefore(PARSER.parse("2020-01-01"));
-		creator.setSecret(KEY);
-		return creator;
-	}
+  @SneakyThrows
+  @Override
+  protected Object retrieveObjectForSampleConfig()
+  {
+    JWTCreator creator = new JWTCreator();
+    creator.setIssuer("me");
+    creator.setSubject("Bob");
+    creator.setAudience("you");
+    creator.setExpiration(PARSER.parse("2040-12-31"));
+    creator.setNotBefore(PARSER.parse("2020-01-01"));
+    creator.setSecret(KEY);
+    return creator;
+  }
 }

--- a/src/test/java/com/adaptris/core/jwt/JWTDecoderTest.java
+++ b/src/test/java/com/adaptris/core/jwt/JWTDecoderTest.java
@@ -55,10 +55,4 @@ public class JWTDecoderTest extends JWTCommonTest
     decoder.setClaims(new StringPayloadDataOutputParameter());
     return decoder;
   }
-
-  @Override
-  public boolean isAnnotatedForJunit4()
-  {
-    return true;
-  }
 }

--- a/src/test/java/com/adaptris/core/jwt/JWTDecoderTest.java
+++ b/src/test/java/com/adaptris/core/jwt/JWTDecoderTest.java
@@ -1,0 +1,67 @@
+package com.adaptris.core.jwt;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.common.ConstantDataInputParameter;
+import com.adaptris.core.common.MetadataDataOutputParameter;
+import com.adaptris.core.common.StringPayloadDataOutputParameter;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.nio.charset.Charset;
+
+import static org.junit.Assert.fail;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+
+public class JWTDecoderTest extends JWTCommonTest
+{
+
+	@Test
+	public void testDecode() throws Exception
+	{
+		JWTDecoder service = (JWTDecoder)retrieveObjectForSampleConfig();
+		AdaptrisMessage message = message();
+
+		service.doService(message);
+
+		assertEquals(HEADER, new JSONObject(message.getMetadataValue("header")), false);
+		assertEquals(CLAIMS, new JSONObject(message.getContent()), false);
+	}
+
+	@Test
+	public void testInvalidKey()
+	{
+		try
+		{
+			JWTDecoder service = (JWTDecoder)retrieveObjectForSampleConfig();
+			service.setSecret(new ConstantDataInputParameter("invalid key"));
+			AdaptrisMessage message = message();
+
+			service.doService(message);
+
+			fail();
+		}
+		catch (ServiceException e)
+		{
+			// expected
+		}
+	}
+
+	@Override
+	protected Object retrieveObjectForSampleConfig()
+	{
+		JWTDecoder decoder = new JWTDecoder();
+		decoder.setJwtString(new ConstantDataInputParameter(JWT));
+		decoder.setSecret(new ConstantDataInputParameter(KEY));
+		decoder.setHeader(new MetadataDataOutputParameter("header"));
+		decoder.setClaims(new StringPayloadDataOutputParameter());
+		return decoder;
+	}
+
+	@Override
+	public boolean isAnnotatedForJunit4()
+	{
+		return true;
+	}
+}

--- a/src/test/java/com/adaptris/core/jwt/JWTDecoderTest.java
+++ b/src/test/java/com/adaptris/core/jwt/JWTDecoderTest.java
@@ -1,15 +1,12 @@
 package com.adaptris.core.jwt;
 
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.DefaultMessageFactory;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.common.ConstantDataInputParameter;
 import com.adaptris.core.common.MetadataDataOutputParameter;
 import com.adaptris.core.common.StringPayloadDataOutputParameter;
 import org.json.JSONObject;
 import org.junit.Test;
-
-import java.nio.charset.Charset;
 
 import static org.junit.Assert.fail;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;

--- a/src/test/java/com/adaptris/core/jwt/JWTDecoderTest.java
+++ b/src/test/java/com/adaptris/core/jwt/JWTDecoderTest.java
@@ -17,51 +17,51 @@ import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 public class JWTDecoderTest extends JWTCommonTest
 {
 
-	@Test
-	public void testDecode() throws Exception
-	{
-		JWTDecoder service = (JWTDecoder)retrieveObjectForSampleConfig();
-		AdaptrisMessage message = message();
+  @Test
+  public void testDecode() throws Exception
+  {
+    JWTDecoder service = (JWTDecoder)retrieveObjectForSampleConfig();
+    AdaptrisMessage message = message();
 
-		service.doService(message);
+    service.doService(message);
 
-		assertEquals(HEADER, new JSONObject(message.getMetadataValue("header")), false);
-		assertEquals(CLAIMS, new JSONObject(message.getContent()), false);
-	}
+    assertEquals(HEADER, new JSONObject(message.getMetadataValue("header")), false);
+    assertEquals(CLAIMS, new JSONObject(message.getContent()), false);
+  }
 
-	@Test
-	public void testInvalidKey()
-	{
-		try
-		{
-			JWTDecoder service = (JWTDecoder)retrieveObjectForSampleConfig();
-			service.setSecret(new ConstantDataInputParameter("invalid key"));
-			AdaptrisMessage message = message();
+  @Test
+  public void testInvalidKey()
+  {
+    try
+    {
+      JWTDecoder service = (JWTDecoder)retrieveObjectForSampleConfig();
+      service.setSecret(new ConstantDataInputParameter("invalid key"));
+      AdaptrisMessage message = message();
 
-			service.doService(message);
+      service.doService(message);
 
-			fail();
-		}
-		catch (ServiceException e)
-		{
-			// expected
-		}
-	}
+      fail();
+    }
+    catch (ServiceException e)
+    {
+      // expected
+    }
+  }
 
-	@Override
-	protected Object retrieveObjectForSampleConfig()
-	{
-		JWTDecoder decoder = new JWTDecoder();
-		decoder.setJwtString(new ConstantDataInputParameter(JWT));
-		decoder.setSecret(new ConstantDataInputParameter(KEY));
-		decoder.setHeader(new MetadataDataOutputParameter("header"));
-		decoder.setClaims(new StringPayloadDataOutputParameter());
-		return decoder;
-	}
+  @Override
+  protected Object retrieveObjectForSampleConfig()
+  {
+    JWTDecoder decoder = new JWTDecoder();
+    decoder.setJwtString(new ConstantDataInputParameter(JWT));
+    decoder.setSecret(new ConstantDataInputParameter(KEY));
+    decoder.setHeader(new MetadataDataOutputParameter("header"));
+    decoder.setClaims(new StringPayloadDataOutputParameter());
+    return decoder;
+  }
 
-	@Override
-	public boolean isAnnotatedForJunit4()
-	{
-		return true;
-	}
+  @Override
+  public boolean isAnnotatedForJunit4()
+  {
+    return true;
+  }
 }

--- a/src/test/java/com/adaptris/core/jwt/JWTEncoderTest.java
+++ b/src/test/java/com/adaptris/core/jwt/JWTEncoderTest.java
@@ -19,74 +19,74 @@ import static org.junit.Assert.fail;
 
 public class JWTEncoderTest extends JWTCommonTest
 {
-	@Test
-	public void testEncode() throws Exception
-	{
-		JWTEncoder service = (JWTEncoder)retrieveObjectForSampleConfig();
-		AdaptrisMessage message = message();
+  @Test
+  public void testEncode() throws Exception
+  {
+    JWTEncoder service = (JWTEncoder)retrieveObjectForSampleConfig();
+    AdaptrisMessage message = message();
 
-		service.doService(message);
+    service.doService(message);
 
-		assertEquals(JWT, message.getContent());
-	}
+    assertEquals(JWT, message.getContent());
+  }
 
-	@Test
-	public void testRandomKey() throws Exception
-	{
-		JWTEncoder service = (JWTEncoder)retrieveObjectForSampleConfig();
-		AdaptrisMessage message = message();
+  @Test
+  public void testRandomKey() throws Exception
+  {
+    JWTEncoder service = (JWTEncoder)retrieveObjectForSampleConfig();
+    AdaptrisMessage message = message();
 
-		service.setGenerateKey(true);
-		service.setKeyOutput(new MetadataDataOutputParameter("key"));
+    service.setGenerateKey(true);
+    service.setKeyOutput(new MetadataDataOutputParameter("key"));
 
-		service.doService(message);
+    service.doService(message);
 
-		JWTDecoder decoder = new JWTDecoder();
-		decoder.setJwtString(new StringPayloadDataInputParameter());
-		decoder.setSecret(new MetadataDataInputParameter("key"));
-		decoder.setHeader(new MetadataDataOutputParameter("header"));
-		decoder.setClaims(new StringPayloadDataOutputParameter());
+    JWTDecoder decoder = new JWTDecoder();
+    decoder.setJwtString(new StringPayloadDataInputParameter());
+    decoder.setSecret(new MetadataDataInputParameter("key"));
+    decoder.setHeader(new MetadataDataOutputParameter("header"));
+    decoder.setClaims(new StringPayloadDataOutputParameter());
 
-		decoder.doService(message);
+    decoder.doService(message);
 
-		JSONAssert.assertEquals(HEADER, new JSONObject(message.getMetadataValue("header")), false);
-		JSONAssert.assertEquals(CLAIMS, new JSONObject(message.getContent()), false);
-	}
+    JSONAssert.assertEquals(HEADER, new JSONObject(message.getMetadataValue("header")), false);
+    JSONAssert.assertEquals(CLAIMS, new JSONObject(message.getContent()), false);
+  }
 
-	@Test
-	public void testNoKeyOutput()
-	{
-		try
-		{
-			JWTEncoder service = (JWTEncoder)retrieveObjectForSampleConfig();
-			AdaptrisMessage message = message();
+  @Test
+  public void testNoKeyOutput()
+  {
+    try
+    {
+      JWTEncoder service = (JWTEncoder)retrieveObjectForSampleConfig();
+      AdaptrisMessage message = message();
 
-			service.setGenerateKey(true);
+      service.setGenerateKey(true);
 
-			service.doService(message);
+      service.doService(message);
 
-			fail();
-		}
-		catch (ServiceException e)
-		{
-			// expected
-		}
-	}
+      fail();
+    }
+    catch (ServiceException e)
+    {
+      // expected
+    }
+  }
 
-	@Override
-	protected Object retrieveObjectForSampleConfig()
-	{
-		JWTEncoder encoder = new JWTEncoder();
-		encoder.setSecret(new ConstantDataInputParameter(KEY));
-		encoder.setHeader(new ConstantDataInputParameter(HEADER.toString()));
-		encoder.setClaims(new ConstantDataInputParameter(CLAIMS.toString()));
-		encoder.setJwtOutput(new StringPayloadDataOutputParameter());
-		return encoder;
-	}
+  @Override
+  protected Object retrieveObjectForSampleConfig()
+  {
+    JWTEncoder encoder = new JWTEncoder();
+    encoder.setSecret(new ConstantDataInputParameter(KEY));
+    encoder.setHeader(new ConstantDataInputParameter(HEADER.toString()));
+    encoder.setClaims(new ConstantDataInputParameter(CLAIMS.toString()));
+    encoder.setJwtOutput(new StringPayloadDataOutputParameter());
+    return encoder;
+  }
 
-	@Override
-	public boolean isAnnotatedForJunit4()
-	{
-		return true;
-	}
+  @Override
+  public boolean isAnnotatedForJunit4()
+  {
+    return true;
+  }
 }

--- a/src/test/java/com/adaptris/core/jwt/JWTEncoderTest.java
+++ b/src/test/java/com/adaptris/core/jwt/JWTEncoderTest.java
@@ -1,7 +1,6 @@
 package com.adaptris.core.jwt;
 
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.DefaultMessageFactory;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.common.ConstantDataInputParameter;
 import com.adaptris.core.common.MetadataDataInputParameter;
@@ -11,8 +10,6 @@ import com.adaptris.core.common.StringPayloadDataOutputParameter;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
-
-import java.nio.charset.Charset;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;

--- a/src/test/java/com/adaptris/core/jwt/JWTEncoderTest.java
+++ b/src/test/java/com/adaptris/core/jwt/JWTEncoderTest.java
@@ -24,7 +24,8 @@ public class JWTEncoderTest extends JWTCommonTest
 
     service.doService(message);
 
-    assertEquals(JWT, message.getContent());
+    String s = message.getContent();
+    assertEquals(JWT, s);
   }
 
   @Test
@@ -79,11 +80,5 @@ public class JWTEncoderTest extends JWTCommonTest
     encoder.setClaims(new ConstantDataInputParameter(CLAIMS.toString()));
     encoder.setJwtOutput(new StringPayloadDataOutputParameter());
     return encoder;
-  }
-
-  @Override
-  public boolean isAnnotatedForJunit4()
-  {
-    return true;
   }
 }

--- a/src/test/java/com/adaptris/core/jwt/JWTEncoderTest.java
+++ b/src/test/java/com/adaptris/core/jwt/JWTEncoderTest.java
@@ -1,0 +1,92 @@
+package com.adaptris.core.jwt;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.common.ConstantDataInputParameter;
+import com.adaptris.core.common.MetadataDataInputParameter;
+import com.adaptris.core.common.MetadataDataOutputParameter;
+import com.adaptris.core.common.StringPayloadDataInputParameter;
+import com.adaptris.core.common.StringPayloadDataOutputParameter;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import java.nio.charset.Charset;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class JWTEncoderTest extends JWTCommonTest
+{
+	@Test
+	public void testEncode() throws Exception
+	{
+		JWTEncoder service = (JWTEncoder)retrieveObjectForSampleConfig();
+		AdaptrisMessage message = message();
+
+		service.doService(message);
+
+		assertEquals(JWT, message.getContent());
+	}
+
+	@Test
+	public void testRandomKey() throws Exception
+	{
+		JWTEncoder service = (JWTEncoder)retrieveObjectForSampleConfig();
+		AdaptrisMessage message = message();
+
+		service.setGenerateKey(true);
+		service.setKeyOutput(new MetadataDataOutputParameter("key"));
+
+		service.doService(message);
+
+		JWTDecoder decoder = new JWTDecoder();
+		decoder.setJwtString(new StringPayloadDataInputParameter());
+		decoder.setSecret(new MetadataDataInputParameter("key"));
+		decoder.setHeader(new MetadataDataOutputParameter("header"));
+		decoder.setClaims(new StringPayloadDataOutputParameter());
+
+		decoder.doService(message);
+
+		JSONAssert.assertEquals(HEADER, new JSONObject(message.getMetadataValue("header")), false);
+		JSONAssert.assertEquals(CLAIMS, new JSONObject(message.getContent()), false);
+	}
+
+	@Test
+	public void testNoKeyOutput()
+	{
+		try
+		{
+			JWTEncoder service = (JWTEncoder)retrieveObjectForSampleConfig();
+			AdaptrisMessage message = message();
+
+			service.setGenerateKey(true);
+
+			service.doService(message);
+
+			fail();
+		}
+		catch (ServiceException e)
+		{
+			// expected
+		}
+	}
+
+	@Override
+	protected Object retrieveObjectForSampleConfig()
+	{
+		JWTEncoder encoder = new JWTEncoder();
+		encoder.setSecret(new ConstantDataInputParameter(KEY));
+		encoder.setHeader(new ConstantDataInputParameter(HEADER.toString()));
+		encoder.setClaims(new ConstantDataInputParameter(CLAIMS.toString()));
+		encoder.setJwtOutput(new StringPayloadDataOutputParameter());
+		return encoder;
+	}
+
+	@Override
+	public boolean isAnnotatedForJunit4()
+	{
+		return true;
+	}
+}


### PR DESCRIPTION
## Motivation

Request for services that encode/decode JWT (JSON web tokens).

## Modification

Add two new services, and unit tests, to existing JSON optional component as suggested by @aaron-mcgrath-adp . Although, they could easily be moved to their own optional component project if desired.

## Result

The encode service allows for JSON to be signed and encoded to the JWT standard, and the decode service verify a signed JWT string as well as providing the decoded JSON header/body.

## Testing

There are two unit test files, which share the same test data. The output from one is the input to the other. Alternatively, fire up an Adapter with a workflow that includes the two services and check the output matches the input.
