### PR TITLE
feature/INTERLOK-3361

### DIFF
--- a/src/main/java/com/adaptris/core/json/schema/DefaultValidationExceptionHandler.java
+++ b/src/main/java/com/adaptris/core/json/schema/DefaultValidationExceptionHandler.java
@@ -23,7 +23,6 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @ComponentProfile(summary = "Throw an exception if validation fails during schema validation", tag = "json,validation")
 public class DefaultValidationExceptionHandler extends ValidationExceptionHandlerImpl {
 
-
   @Override
   public void handle(ValidationException exc, AdaptrisMessage msg) throws ServiceException {
     throw ExceptionHelper.wrapServiceException(buildExceptionMessage(exc), exc);
@@ -33,9 +32,9 @@ public class DefaultValidationExceptionHandler extends ValidationExceptionHandle
     String prefix = exc.getMessage() + ": ";
     Map<Integer, String> map = new TreeMap<>();
     int count = 0;
-    for (ValidationException ve : exc.getCausingExceptions()) {
-      log.error(ve.getMessage());
-      map.put(++count, ve.getMessage());
+    for (String ve : exc.getAllMessages()) {
+      log.error(ve);
+      map.put(++count, ve);
     }
     return prefix + map;
   }

--- a/src/main/java/com/adaptris/core/json/schema/ModifyPayloadExceptionHandler.java
+++ b/src/main/java/com/adaptris/core/json/schema/ModifyPayloadExceptionHandler.java
@@ -29,7 +29,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
     }
    }
  * </pre>
- * 
+ *
  * @config json-schema-validation-exception-into-message
  */
 @XStreamAlias("json-schema-validation-exception-into-message")
@@ -56,12 +56,12 @@ public class ModifyPayloadExceptionHandler extends ValidationExceptionHandlerImp
       Object json = jsonify(msg.getContent());
       ArrayList<String> violations = new ArrayList<>();
       violations.add(exc.getMessage());
-      for (ValidationException ve : exc.getCausingExceptions()) {
-        violations.add(ve.getMessage());
+      for (String ve : exc.getAllMessages()) {
+        violations.add(ve);
       }
       Map<String, Object> newMsg = new HashMap<>();
       newMsg.put("original", json);
-      newMsg.put("schema-violations", violations);
+      newMsg.put("schema-violations", violations.toString());
       try (Writer w = msg.getWriter()) {
         mapper.writeValue(w, newMsg);
       }
@@ -80,7 +80,7 @@ public class ModifyPayloadExceptionHandler extends ValidationExceptionHandlerImp
 
   /**
    * After adding the ValidationException to the payload throw an exception.
-   * 
+   *
    * @param b true to throw an exception; false otherwise (default false).
    */
   public void setThrowException(Boolean b) {

--- a/src/main/java/com/adaptris/core/json/schema/ModifyPayloadExceptionHandler.java
+++ b/src/main/java/com/adaptris/core/json/schema/ModifyPayloadExceptionHandler.java
@@ -61,7 +61,7 @@ public class ModifyPayloadExceptionHandler extends ValidationExceptionHandlerImp
       }
       Map<String, Object> newMsg = new HashMap<>();
       newMsg.put("original", json);
-      newMsg.put("schema-violations", violations.toString());
+      newMsg.put("schema-violations", violations);
       try (Writer w = msg.getWriter()) {
         mapper.writeValue(w, newMsg);
       }


### PR DESCRIPTION
Correctly ensure that all schema validation errors are included (in the logs or payload).

## Motivation

Not all of the schema validation errors are included, when they should be; only the first was available.

## Modification

Change calls from getCausingExceptions() to getAllMessages()

## Result

All schema validation errors are now present.

## Testing

Test data is available in the Jira ticket.
