### PR TITLE
Feature/interlok 3060 jolt transform stored as yaml

### DIFF
--- a/src/test/java/com/adaptris/core/transform/json/JsonTransformServiceTest.java
+++ b/src/test/java/com/adaptris/core/transform/json/JsonTransformServiceTest.java
@@ -1,11 +1,15 @@
 package com.adaptris.core.transform.json;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
 import org.junit.Before;
 import org.junit.Test;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConfiguredDestination;
 import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.ServiceException;
 import com.adaptris.core.common.ConstantDataInputParameter;
 import com.adaptris.core.common.FileDataInputParameter;
 import com.adaptris.core.common.MetadataDataInputParameter;
@@ -15,22 +19,22 @@ import com.adaptris.core.metadata.NoOpMetadataFilter;
 import com.adaptris.core.transform.TransformServiceExample;
 
 public class JsonTransformServiceTest extends TransformServiceExample {
-  
+
   private static final String METADATA_KEY = "data-key";
-  
+
   private JsonTransformService service;
   private StringPayloadDataInputParameter payloadInput;
   private StringPayloadDataOutputParameter payloadOutput;
   private MetadataDataInputParameter metadataInput;
   private ConstantDataInputParameter constantInput;
-  
+
   private AdaptrisMessage message;
 
   @Override
   public boolean isAnnotatedForJunit4() {
     return true;
   }
-  
+
   @Before
   public void setUp() throws Exception {
     service = new JsonTransformService();
@@ -40,21 +44,21 @@ public class JsonTransformServiceTest extends TransformServiceExample {
     constantInput = new ConstantDataInputParameter(sampleSpec);
     message = DefaultMessageFactory.getDefaultInstance().newMessage();
   }
-  
+
   @Test
   public void testSimpleTransform_MetadataInputMapping() throws Exception {
     service.setSourceJson(payloadInput);
     service.setMappingSpec(metadataInput);
     service.setTargetJson(payloadOutput);
-    
+
     message.setContent(sampleInput, message.getContentEncoding());
     message.addMetadata(METADATA_KEY, sampleSpec);
-    
+
     service.doService(message);
-    
+
     assertEquals(sampleOutput, message.getContent());
   }
-  
+
   @Test
   public void testSimpleTransform_ConstantInputMapping() throws Exception {
     service.setSourceJson(payloadInput);
@@ -74,35 +78,67 @@ public class JsonTransformServiceTest extends TransformServiceExample {
     service.setSourceJson(payloadInput);
     service.setMappingSpec(metadataInput);
     service.setTargetJson(payloadOutput);
-    
+
     service.setMetadataFilter(new NoOpMetadataFilter());
-    
+
     message.setContent(sampleInput, message.getContentEncoding());
     message.addMetadata(METADATA_KEY, sampleSpec);
     message.addMetadata("SomeKey", "SomeValue");
-    
+
     service.doService(message);
-    
+
     assertEquals(sampleOutput, message.getContent());
   }
-  
+
   @Test
   public void testSimpleTransformWithVarSub() throws Exception {
     service.setSourceJson(payloadInput);
     service.setMappingSpec(metadataInput);
     service.setTargetJson(payloadOutput);
-    
+
     service.setMetadataFilter(new NoOpMetadataFilter());
-    
+
     message.setContent(sampleInput, message.getContentEncoding());
     message.addMetadata(METADATA_KEY, sampleSpecVarSub);
     message.addMetadata("tertiary-ratings", "TertiaryRatings");
-    
+
     service.doService(message);
-    
+
     assertEquals(sampleOutputVarSub, message.getContent());
   }
-  
+
+  @Test
+  public void testSimpleTransformWithYaml() throws Exception {
+    service.setSourceJson(payloadInput);
+    service.setMappingSpec(metadataInput);
+    service.setTargetJson(payloadOutput);
+
+    service.setMetadataFilter(new NoOpMetadataFilter());
+
+    message.setContent(sampleInput, message.getContentEncoding());
+    message.addMetadata(METADATA_KEY, sampleSpecYaml);
+    message.addMetadata("SomeKey", "SomeValue");
+
+    service.doService(message);
+
+    assertEquals(sampleOutput, message.getContent());
+  }
+
+  @Test
+  public void testSimpleTransformWithInvalidJsonAndYaml() throws Exception {
+    service.setSourceJson(payloadInput);
+    service.setMappingSpec(metadataInput);
+    service.setTargetJson(payloadOutput);
+
+    service.setMetadataFilter(new NoOpMetadataFilter());
+
+    message.setContent(sampleInput, message.getContentEncoding());
+    message.addMetadata(METADATA_KEY, "Invalid jolt specs");
+    message.addMetadata("SomeKey", "SomeValue");
+
+    assertThrows(ServiceException.class, () -> service.doService(message));
+  }
+
   @Override
   protected Object retrieveObjectForSampleConfig() {
     service.setSourceJson(payloadInput);
@@ -110,81 +146,97 @@ public class JsonTransformServiceTest extends TransformServiceExample {
     in.setDestination(new ConfiguredDestination("file:///path/to/my/mapping.json"));
     service.setMappingSpec(in);
     service.setTargetJson(payloadOutput);
-    
+
     return service;
   }
 
   private String sampleInput = ""
-      + "{" + 
-    "\"rating\": {" + 
-    "    \"primary\": {" + 
-    "        \"values\": 3" +
-    "    }," +
-    "    \"quality\": {" +
-    "        \"values\": 3" +
-    "    }" +
-    "}" +
-    "}";
-  
+      + "{" +
+      "\"rating\": {" +
+      "    \"primary\": {" +
+      "        \"values\": 3" +
+      "    }," +
+      "    \"quality\": {" +
+      "        \"values\": 3" +
+      "    }" +
+      "}" +
+      "}";
+
   private String sampleSpec = ""
       + "[" +
-    "{" + 
-    "    \"operation\": \"shift\"," + 
-    "    \"spec\": {" + 
-    "        \"rating\": {" + 
-    "            \"primary\": {" + 
-    "                \"values\": \"Rating\"" +
-    "            }," +
-    "            \"*\": {" +
-    "                \"values\": \"SecondaryRatings.&1.Value\"," +
-    "                \"$\": \"SecondaryRatings.&.Id\"" + 
-    "            }" +
-    "        }" +
-    "    }" +
-    "}," +
-    "{" +
-    "    \"operation\": \"default\"," + 
-    "    \"spec\": {" +
-    "        \"Range\" : 5," +
-    "        \"SecondaryRatings\" : {" +
-    "            \"*\" : {" +
-    "                \"Range\" : 5" +
-    "            }" +
-    "        }" +
-    "    }" +
-    "}" +
-    "]";
-  
+      "{" +
+      "    \"operation\": \"shift\"," +
+      "    \"spec\": {" +
+      "        \"rating\": {" +
+      "            \"primary\": {" +
+      "                \"values\": \"Rating\"" +
+      "            }," +
+      "            \"*\": {" +
+      "                \"values\": \"SecondaryRatings.&1.Value\"," +
+      "                \"$\": \"SecondaryRatings.&.Id\"" +
+      "            }" +
+      "        }" +
+      "    }" +
+      "}," +
+      "{" +
+      "    \"operation\": \"default\"," +
+      "    \"spec\": {" +
+      "        \"Range\" : 5," +
+      "        \"SecondaryRatings\" : {" +
+      "            \"*\" : {" +
+      "                \"Range\" : 5" +
+      "            }" +
+      "        }" +
+      "    }" +
+      "}" +
+      "]";
+
   private String sampleSpecVarSub = ""
       + "[" +
-    "{" + 
-    "    \"operation\": \"shift\"," + 
-    "    \"spec\": {" + 
-    "        \"rating\": {" + 
-    "            \"primary\": {" + 
-    "                \"values\": \"Rating\"" +
-    "            }," +
-    "            \"*\": {" +
-    "                \"values\": \"${tertiary-ratings}.&1.Value\"," +
-    "                \"$\": \"${tertiary-ratings}.&.Id\"" + 
-    "            }" +
-    "        }" +
-    "    }" +
-    "}," +
-    "{" +
-    "    \"operation\": \"default\"," + 
-    "    \"spec\": {" +
-    "        \"Range\" : 5," +
-    "        \"${tertiary-ratings}\" : {" +
-    "            \"*\" : {" +
-    "                \"Range\" : 5" +
-    "            }" +
-    "        }" +
-    "    }" +
-    "}" +
-    "]";
-  
+      "{" +
+      "    \"operation\": \"shift\"," +
+      "    \"spec\": {" +
+      "        \"rating\": {" +
+      "            \"primary\": {" +
+      "                \"values\": \"Rating\"" +
+      "            }," +
+      "            \"*\": {" +
+      "                \"values\": \"${tertiary-ratings}.&1.Value\"," +
+      "                \"$\": \"${tertiary-ratings}.&.Id\"" +
+      "            }" +
+      "        }" +
+      "    }" +
+      "}," +
+      "{" +
+      "    \"operation\": \"default\"," +
+      "    \"spec\": {" +
+      "        \"Range\" : 5," +
+      "        \"${tertiary-ratings}\" : {" +
+      "            \"*\" : {" +
+      "                \"Range\" : 5" +
+      "            }" +
+      "        }" +
+      "    }" +
+      "}" +
+      "]";
+
+  private String sampleSpecYaml = ""
+      + "- operation: shift\r\n" +
+      "  spec:\r\n" +
+      "    rating:\r\n" +
+      "      primary:\r\n" +
+      "        values: Rating\r\n" +
+      "      \"*\":\r\n" +
+      "        values: SecondaryRatings.&1.Value\r\n" +
+      "        \"$\": SecondaryRatings.&.Id\r\n" +
+      "- operation: default\r\n" +
+      "  spec:\r\n" +
+      "    Range: 5\r\n" +
+      "    SecondaryRatings:\r\n" +
+      "      \"*\":\r\n" +
+      "        Range: 5\r\n";
+
   private String sampleOutput = "{\"Rating\":3,\"SecondaryRatings\":{\"quality\":{\"Id\":\"quality\",\"Value\":3,\"Range\":5}},\"Range\":5}";
-  
+
   private String sampleOutputVarSub = "{\"Rating\":3,\"TertiaryRatings\":{\"quality\":{\"Id\":\"quality\",\"Value\":3,\"Range\":5}},\"Range\":5}";
 }


### PR DESCRIPTION
## Motivation

Make it easier to write Jolt transform specifications

## Modification

- When the specs doesn't start by a json array we use a YAMLFactory when creating an ObjectMapper to read the Jolt specs.
- Added unit tests for the changes.

## Result

We can write json and yaml Jolt specs.

## Testing

Test that the JsonTransformService still works with json specs.
Test that the JsonTransformService  works with the same results when using equivalent yaml specs.
