### PR TITLE
INTERLOK-2601 Transformation driver API Change

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -236,6 +236,7 @@ javadoc {
   configure(options) {
     options.linksOffline(interlokJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-core-$interlokCoreVersion-javadoc.jar")
     options.linksOffline(interlokCommonJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-common-$interlokCoreVersion-javadoc.jar")
+    options.tags('apiNote:a:API Note:', 'implSpec:a:Implementation Requirements:','implNote:a:Implementation Note:')
     taglets = ["com.adaptris.taglet.ConfigTaglet", "com.adaptris.taglet.LicenseTaglet"]
     options.addStringOption "tagletpath", configurations.javadoc.asPath
     options.group ("Transformation/Validation", ["com.adaptris.core.transform.json.*" , "com.adaptris.core.transform.json", "com.adaptris.core.json.schema", "com.adaptris.core.json.schema.*"]).
@@ -298,6 +299,7 @@ task umlJavadoc(type: Javadoc) {
   configure(options) {
     options.linksOffline(interlokJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-core-$interlokCoreVersion-javadoc.jar")
     options.linksOffline(interlokCommonJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-common-$interlokCoreVersion-javadoc.jar")
+    options.tags('apiNote:a:API Note:', 'implSpec:a:Implementation Requirements:','implNote:a:Implementation Note:')
     taglets = ["com.adaptris.taglet.ConfigTaglet", "com.adaptris.taglet.LicenseTaglet"]
     options.addStringOption "tagletpath", configurations.javadoc.asPath
     options.docletpath = configurations.umlDoclet.files.asType(List)

--- a/src/main/java/com/adaptris/core/transform/json/JsonXmlTransformService.java
+++ b/src/main/java/com/adaptris/core/transform/json/JsonXmlTransformService.java
@@ -14,18 +14,6 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * XML to JSON converter and vice versa.
- * <p>
- * This service requires BOTH json.jar and json-lib-2.4-jdk15.jar on the classpath, since it supports both libraries to perform the
- * conversion. Select a transformation driver to determine which library to use. The "simple" library (json.jar) yields simpler
- * looking and cleaner XML, but will sometimes cause problems transforming XML elements into JSON arrays. The simple driver will
- * behave exactly like the legacy JSON services, including requiring and generating an XML element names "json" to wrap the
- * generated Xml.
- * </p>
- * <p>
- * The Default transformation driver uses json-lib-2.4-jdk15.jar and has a more complicated, but more information rich XML format.
- * This format can then be used to precisely control the JSON output when converting to JSON, resolving issues like improper array
- * generation. This driver always takes the entire message body as input and does not support converting only a part of it.
- * </p>
  *
  * @config json-xml-transform-service
  *
@@ -67,7 +55,7 @@ public class JsonXmlTransformService extends ServiceImp {
    */
   @Override
   public void doService(final AdaptrisMessage msg) throws ServiceException {
-    msg.setContent(driver.transform(msg.getContent(), direction), msg.getContentEncoding());
+    driver.transform(msg, getDirection());
   }
 
   @Override
@@ -107,7 +95,7 @@ public class JsonXmlTransformService extends ServiceImp {
     setDirection(d);
     return this;
   }
-  
+
   /**
    * Get the transformation driver.
    *
@@ -125,7 +113,7 @@ public class JsonXmlTransformService extends ServiceImp {
   public void setDriver(final TransformationDriver driver) {
     this.driver = driver;
   }
-  
+
   public JsonXmlTransformService withDriver(TransformationDriver d) {
     setDriver(d);
     return this;

--- a/src/main/java/com/adaptris/core/transform/json/TransformationDriver.java
+++ b/src/main/java/com/adaptris/core/transform/json/TransformationDriver.java
@@ -1,5 +1,7 @@
 package com.adaptris.core.transform.json;
 
+import com.adaptris.annotation.Removal;
+import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
 
 /**
@@ -7,17 +9,35 @@ import com.adaptris.core.ServiceException;
  */
 public interface TransformationDriver {
 	/**
-	 * Perform transformation.
-	 *
-	 * @param input
-	 *          The data to transform.
-	 * @param direction
-	 *          The direction of the transformation.
-	 *
-	 * @return The transformed data.
-	 *
-	 * @throws ServiceException
-	 *           Thrown if there is a problem with the transformation.
-	 */
-	public String transform(String input, TransformationDirection direction) throws ServiceException;
+   * Perform transformation.
+   *
+   * @param input The data to transform.
+   * @param direction The direction of the transformation.
+   * @return The transformed data.
+   * @throws ServiceException Thrown if there is a problem with the transformation.
+   * @deprecated since 3.11.0 use the {@link #transform(AdaptrisMessage, TransformationDirection)}
+   *             instead.
+   * @implNote The default implementation throws an {@link UnsupportedOperationException}.
+   */
+  @Deprecated
+  @Removal(version = "4.0.0")
+  default String transform(String input, TransformationDirection direction)
+      throws ServiceException {
+    throw new UnsupportedOperationException("Use transform(AdaptrisMessage, direction) instead");
+  }
+
+  /**
+   * Perform the transformation.
+   *
+   * @param msg The data to transform.
+   * @param direction The direction of the transformation.
+   * @throws ServiceException Thrown if there is a problem with the transformation.
+   * @implNote The default implementation just delegates to
+   *           {@link #transform(String, TransformationDirection)}.
+   *
+   */
+  default void transform(AdaptrisMessage msg, TransformationDirection direction)
+      throws ServiceException {
+    msg.setContent(transform(msg.getContent(), direction), msg.getContentEncoding());
+  }
 }

--- a/src/test/java/com/adaptris/core/json/JsonToMetadataTest.java
+++ b/src/test/java/com/adaptris/core/json/JsonToMetadataTest.java
@@ -5,15 +5,15 @@ import static org.junit.Assert.assertNull;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ServiceCase;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 import com.adaptris.util.text.NullPassThroughConverter;
 
-public class JsonToMetadataTest extends ServiceCase {
-  
-  private static String SAMPLE_JSON_CONTENT = 
+public class JsonToMetadataTest extends ExampleServiceCase {
+
+  private static String SAMPLE_JSON_CONTENT =
      "\"category\": \"fiction\","
     + "\"title\": \"The Lord of the Rings Trilogy\","
-    + "\"price\": 22.99," 
+    + "\"price\": 22.99,"
     + "\"volumes\" : [1,2,3]";
 
   private static String JSON_START = "{";
@@ -23,10 +23,6 @@ public class JsonToMetadataTest extends ServiceCase {
   private static String NESTED_OBJECT = "\"suggested\": " + JSON_START + NESTED_CONTENT + JSON_END;
   private static String SAMPLE_JSON = JSON_START + SAMPLE_JSON_CONTENT + "," + NESTED_OBJECT + JSON_END;
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
   @Test
   public void testSetNullConverter() throws Exception {
     JsonToMetadata service = new JsonToMetadata();
@@ -82,7 +78,7 @@ public class JsonToMetadataTest extends ServiceCase {
     return new JsonToMetadata();
   }
 
-  
+
 
 
 }

--- a/src/test/java/com/adaptris/core/json/VerifyIsJsonTest.java
+++ b/src/test/java/com/adaptris/core/json/VerifyIsJsonTest.java
@@ -3,18 +3,13 @@ package com.adaptris.core.json;
 import java.util.Map;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.json.DeserializerCase.TypeKey;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 
-public class VerifyIsJsonTest extends ServiceCase {
+public class VerifyIsJsonTest extends ExampleServiceCase {
 
   private Map<TypeKey, AdaptrisMessage> messageTypes = DeserializerCase.createMessageFlavours();
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
 
   @Test
   public void testService() throws Exception {

--- a/src/test/java/com/adaptris/core/json/aggregator/JsonArrayAggregatorFilterTest.java
+++ b/src/test/java/com/adaptris/core/json/aggregator/JsonArrayAggregatorFilterTest.java
@@ -10,14 +10,14 @@ import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.Service;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.json.JsonToMetadata;
 import com.adaptris.core.services.conditional.conditions.ConditionMetadata;
 import com.adaptris.core.services.conditional.operator.Equals;
 import com.adaptris.core.services.splitter.SplitJoinService;
 import com.adaptris.core.services.splitter.json.JsonArraySplitter;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 
-public class JsonArrayAggregatorFilterTest extends ServiceCase {
+public class JsonArrayAggregatorFilterTest extends ExampleServiceCase {
 
   private static final String AGX_GROWERS_LIST_URL = "/growers-sync16.json";
 
@@ -25,11 +25,6 @@ public class JsonArrayAggregatorFilterTest extends ServiceCase {
   public JsonArrayAggregatorFilterTest() { }
 
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
-  
   @Override
   protected Object retrieveObjectForSampleConfig() {
     SplitJoinService service = new SplitJoinService();

--- a/src/test/java/com/adaptris/core/json/aggregator/JsonArrayAggregatorTest.java
+++ b/src/test/java/com/adaptris/core/json/aggregator/JsonArrayAggregatorTest.java
@@ -14,13 +14,13 @@ import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.NullService;
 import com.adaptris.core.Service;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.ServiceCollection;
 import com.adaptris.core.ServiceList;
 import com.adaptris.core.services.LogMessageService;
 import com.adaptris.core.services.conditional.conditions.ConditionImpl;
 import com.adaptris.core.services.splitter.SplitJoinService;
 import com.adaptris.core.services.splitter.json.JsonArraySplitter;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
@@ -28,7 +28,7 @@ import com.jayway.jsonpath.ReadContext;
 import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 
-public class JsonArrayAggregatorTest extends ServiceCase {
+public class JsonArrayAggregatorTest extends ExampleServiceCase {
 
   protected static final String OBJECT_CONTENT_1 = "{ \"firstname\":\"alice\", \"lastname\":\"smith\", \"dob\":\"2017-01-03\" }";
   protected static final String OBJECT_CONTENT_2 = "{ \"firstname\":\"bob\", \"lastname\":\"smith\", \"dob\":\"2017-01-03\" }";
@@ -36,11 +36,6 @@ public class JsonArrayAggregatorTest extends ServiceCase {
 
   private Configuration jsonConfig;
 
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
   @Before
   public void setUp() throws Exception {
     jsonConfig = new Configuration.ConfigurationBuilder().jsonProvider(new JsonSmartJsonProvider())

--- a/src/test/java/com/adaptris/core/json/aggregator/JsonArrayArrayAggregatorTest.java
+++ b/src/test/java/com/adaptris/core/json/aggregator/JsonArrayArrayAggregatorTest.java
@@ -13,12 +13,12 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.NullService;
 import com.adaptris.core.Service;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.ServiceCollection;
 import com.adaptris.core.ServiceList;
 import com.adaptris.core.services.LogMessageService;
 import com.adaptris.core.services.splitter.SplitJoinService;
 import com.adaptris.core.services.splitter.json.JsonArraySplitter;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
@@ -26,7 +26,7 @@ import com.jayway.jsonpath.ReadContext;
 import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 
-public class JsonArrayArrayAggregatorTest extends ServiceCase {
+public class JsonArrayArrayAggregatorTest extends ExampleServiceCase {
 
   protected static final String OBJECT_CONTENT_1 = "{ \"firstname\":\"alice\", \"lastname\":\"smith\", \"dob\":\"2017-01-03\" }";
   protected static final String OBJECT_CONTENT_2 = "{ \"firstname\":\"bob\", \"lastname\":\"smith\", \"dob\":\"2017-01-03\" }";
@@ -34,11 +34,6 @@ public class JsonArrayArrayAggregatorTest extends ServiceCase {
 
   private Configuration jsonConfig;
 
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
 
   @Before
   public void setUp() throws Exception {

--- a/src/test/java/com/adaptris/core/json/aggregator/JsonMergeAggregatorTest.java
+++ b/src/test/java/com/adaptris/core/json/aggregator/JsonMergeAggregatorTest.java
@@ -15,12 +15,12 @@ import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.NullService;
 import com.adaptris.core.Service;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.ServiceCollection;
 import com.adaptris.core.ServiceList;
 import com.adaptris.core.services.LogMessageService;
 import com.adaptris.core.services.splitter.SplitJoinService;
 import com.adaptris.core.services.splitter.json.JsonArraySplitter;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
@@ -29,18 +29,13 @@ import com.jayway.jsonpath.ReadContext;
 import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 
-public class JsonMergeAggregatorTest extends ServiceCase {
+public class JsonMergeAggregatorTest extends ExampleServiceCase {
   protected static final String PARENT_CONTENT   = "{ \"document_type\":\"master\", \"id\":\"101011\", \"creation_date\":\"2017-01-03\" }";
   protected static final String OBJECT_CONTENT_1 = "{ \"firstname\":\"alice\", \"lastname\":\"smith\", \"dob\":\"2017-01-03\" }";
   protected static final String OBJECT_CONTENT_2 = "{ \"firstname\":\"bob\", \"lastname\":\"smith\", \"dob\":\"2017-01-03\" }";
   protected static final String OBJECT_CONTENT_3 = "{ \"firstname\":\"carol\", \"lastname\":\"smith\", \"dob\":\"2017-01-03\" }";
 
   private Configuration jsonConfig;
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
 
   @Before
   public void setUp() throws Exception {

--- a/src/test/java/com/adaptris/core/json/jdbc/BatchJsonArrayInsertTest.java
+++ b/src/test/java/com/adaptris/core/json/jdbc/BatchJsonArrayInsertTest.java
@@ -12,13 +12,6 @@ import com.adaptris.core.ServiceException;
 
 public class BatchJsonArrayInsertTest extends JdbcJsonInsertCase {
 
-
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
-
   @Test
   public void testAccumulate() throws Exception {
     int[] rc = {1, 2, Statement.EXECUTE_FAILED};

--- a/src/test/java/com/adaptris/core/json/jdbc/InsertJsonArrayTest.java
+++ b/src/test/java/com/adaptris/core/json/jdbc/InsertJsonArrayTest.java
@@ -11,11 +11,6 @@ import com.adaptris.core.services.splitter.json.JsonProvider.JsonStyle;
 
 public class InsertJsonArrayTest extends JdbcJsonInsertCase {
 
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
   @Test
   public void testService() throws Exception {
     createDatabase();

--- a/src/test/java/com/adaptris/core/json/jdbc/InsertJsonObjectTest.java
+++ b/src/test/java/com/adaptris/core/json/jdbc/InsertJsonObjectTest.java
@@ -13,10 +13,6 @@ import com.adaptris.util.text.NullPassThroughConverter;
 public class InsertJsonObjectTest extends JdbcJsonInsertCase {
 
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
   @Test
   public void testSetNullConverter() throws Exception {
     InsertJsonObject service = createService();

--- a/src/test/java/com/adaptris/core/json/jdbc/JdbcJsonInsertCase.java
+++ b/src/test/java/com/adaptris/core/json/jdbc/JdbcJsonInsertCase.java
@@ -9,15 +9,15 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import org.junit.Test;
 import com.adaptris.core.CoreException;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.jdbc.JdbcConnection;
 import com.adaptris.core.services.jdbc.JdbcMapInsert;
 import com.adaptris.core.services.jdbc.JdbcOutputExampleTest;
 import com.adaptris.core.util.JdbcUtil;
 import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 import com.adaptris.util.TimeInterval;
 
-public abstract class JdbcJsonInsertCase extends ServiceCase {
+public abstract class JdbcJsonInsertCase extends ExampleServiceCase {
 
 
   protected static final String ARRAY_CONTENT =

--- a/src/test/java/com/adaptris/core/json/jdbc/UpsertJsonArrayTest.java
+++ b/src/test/java/com/adaptris/core/json/jdbc/UpsertJsonArrayTest.java
@@ -14,11 +14,6 @@ public class UpsertJsonArrayTest extends UpsertJsonCase {
 
 
   @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
-
-  @Override
   protected UpsertJsonArray retrieveObjectForSampleConfig() {
     return (UpsertJsonArray) configureForExamples(createService().withId("id").withTable("myTable"));
   }

--- a/src/test/java/com/adaptris/core/json/jdbc/UpsertJsonObjectTest.java
+++ b/src/test/java/com/adaptris/core/json/jdbc/UpsertJsonObjectTest.java
@@ -12,12 +12,6 @@ import com.adaptris.util.text.NullPassThroughConverter;
 
 public class UpsertJsonObjectTest extends UpsertJsonCase {
 
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
-
   @Override
   protected UpsertJsonObject retrieveObjectForSampleConfig() {
     return (UpsertJsonObject) configureForExamples(createService().withId("id").withTable("myTable"));

--- a/src/test/java/com/adaptris/core/json/jsonpatch/ApplyPatchTest.java
+++ b/src/test/java/com/adaptris/core/json/jsonpatch/ApplyPatchTest.java
@@ -22,24 +22,20 @@ import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.common.MetadataInputStreamWrapper;
 import com.adaptris.core.common.PayloadInputStreamWrapper;
 import com.adaptris.core.common.PayloadOutputStreamWrapper;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 import com.flipkart.zjsonpatch.CompatibilityFlags;
 
-public class ApplyPatchTest extends ServiceCase {
+public class ApplyPatchTest extends ExampleServiceCase {
 
   private static final String SOURCE = "{\"a\": 0,\"b\": [1,2]}";
   private static final String TARGET = " {\"b\": [1,2,0]}";
   private static final String PATCH_TRANSFORM =
       "[{\"op\":\"move\",\"from\":\"/a\",\"path\":\"/b/2\"}]";
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
   @Test
   public void testFlags() throws Exception {
     ApplyPatchService service = new ApplyPatchService();

--- a/src/test/java/com/adaptris/core/json/jsonpatch/GeneratePatchDiffTest.java
+++ b/src/test/java/com/adaptris/core/json/jsonpatch/GeneratePatchDiffTest.java
@@ -23,14 +23,14 @@ import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.common.MetadataInputStreamWrapper;
 import com.adaptris.core.common.PayloadInputStreamWrapper;
 import com.adaptris.core.common.PayloadOutputStreamWrapper;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 import com.flipkart.zjsonpatch.DiffFlags;
 
-public class GeneratePatchDiffTest extends ServiceCase {
+public class GeneratePatchDiffTest extends ExampleServiceCase {
 
   private static final String DIFF_SOURCE = "{\"a\": 0,\"b\": [1,2]}";
   private static final String DIFF_TARGET = " {\"b\": [1,2,0]}";
@@ -38,11 +38,6 @@ public class GeneratePatchDiffTest extends ServiceCase {
       "[{\"op\":\"move\",\"from\":\"/a\",\"path\":\"/b/2\"}]";
 
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
-  
   @Test
   public void testFlags() throws Exception {
     GeneratePatchDiffService service =
@@ -101,7 +96,7 @@ public class GeneratePatchDiffTest extends ServiceCase {
         .withDiffTarget(new MetadataInputStreamWrapper("metadata key containing another json object"))
         .withFlags(PatchDiffFlag.OMIT_MOVE_OPERATION, PatchDiffFlag.OMIT_COPY_OPERATION)
         .withOutput(new PayloadOutputStreamWrapper());
-    
+
     return service;
   }
 }

--- a/src/test/java/com/adaptris/core/json/schema/JsonSchemaServiceTest.java
+++ b/src/test/java/com/adaptris/core/json/schema/JsonSchemaServiceTest.java
@@ -14,8 +14,8 @@ import com.adaptris.core.ServiceException;
 import com.adaptris.core.common.FileDataInputParameter;
 import com.adaptris.core.json.JacksonJsonDeserializer;
 import com.adaptris.core.services.jdbc.BrokenAdaptrisMessage;
-import com.adaptris.core.transform.TransformServiceExample;
 import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.interlok.junit.scaffolding.services.TransformServiceExample;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
@@ -41,11 +41,6 @@ public class JsonSchemaServiceTest extends TransformServiceExample {
   private static final String JSON_ARRAY = "[{ \"rectangle\" : { \"a\" : 5, \"b\" : 5 } }]";
   private static final String INVALID_JSON_ARRAY = "[{ \"rectangle\" : { \"a\" : -5, \"b\" : -5 } }]";
   private static final String INVALID_JSON_STRICT = "{ \"rectangle\" : value }";
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
 
   @Test
   public void testInit() throws Exception {

--- a/src/test/java/com/adaptris/core/services/jdbc/JdbcOutputExampleTest.java
+++ b/src/test/java/com/adaptris/core/services/jdbc/JdbcOutputExampleTest.java
@@ -4,15 +4,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import com.adaptris.core.Service;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.jdbc.DatabaseConnection;
 import com.adaptris.core.jdbc.JdbcConnection;
 import com.adaptris.core.json.jdbc.JdbcJsonArrayOutput;
 import com.adaptris.core.json.jdbc.JdbcJsonOutput;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.KeyValuePairSet;
 
-public class JdbcOutputExampleTest extends ServiceCase {
+public class JdbcOutputExampleTest extends ExampleServiceCase {
   private static final String HYPHEN = "-";
   public static final String BASE_DIR_KEY = "JsonJDBCServiceExamples.baseDir";
 
@@ -40,11 +40,6 @@ public class JdbcOutputExampleTest extends ServiceCase {
   }
 
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
-  
   @Override
   protected Object retrieveObjectForSampleConfig() {
     return null;

--- a/src/test/java/com/adaptris/core/services/jdbc/ResultSetToJsonTest.java
+++ b/src/test/java/com/adaptris/core/services/jdbc/ResultSetToJsonTest.java
@@ -6,21 +6,18 @@ import static com.adaptris.core.services.jdbc.JsonResultSetTranslatorTest.execut
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
-
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
-
 import org.junit.Test;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.jdbc.JdbcConnection;
 import com.adaptris.core.json.jdbc.JdbcJsonOutput;
 import com.adaptris.core.services.jdbc.StyledResultTranslatorImp.ColumnStyle;
 import com.adaptris.core.util.JdbcUtil;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 import com.adaptris.jdbc.JdbcResult;
 import com.jayway.jsonpath.ReadContext;
 
@@ -84,7 +81,7 @@ public class ResultSetToJsonTest {
     service.setStatementCreator(new ConfiguredSQLStatement(SELECT_WITH_ALIAS));
     service.setResultSetTranslator(new JdbcJsonOutput().withColumnStyle(ColumnStyle.LowerCase));
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-    ServiceCase.execute(service, msg);
+    ExampleServiceCase.execute(service, msg);
     ReadContext ctx = createContext(msg);
     assertEquals("john", ctx.read("$.[0].first_name"));
     assertEquals("smith", ctx.read("$.[0].last_name"));
@@ -98,7 +95,7 @@ public class ResultSetToJsonTest {
     service.setStatementCreator(new ConfiguredSQLStatement(SELECT));
     service.setResultSetTranslator(new JdbcJsonOutput());
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-    ServiceCase.execute(service, msg);
+    ExampleServiceCase.execute(service, msg);
     ReadContext ctx = createContext(msg);
     assertEquals("john", ctx.read("$.[0].FIRSTNAME"));
     assertEquals("smith", ctx.read("$.[0].LASTNAME"));

--- a/src/test/java/com/adaptris/core/services/path/json/JsonPathServiceTest.java
+++ b/src/test/java/com/adaptris/core/services/path/json/JsonPathServiceTest.java
@@ -10,7 +10,6 @@ import java.util.EnumSet;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.DefaultMessageFactory;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.common.ConstantDataInputParameter;
 import com.adaptris.core.common.Execution;
@@ -19,6 +18,7 @@ import com.adaptris.core.common.MetadataDataOutputParameter;
 import com.adaptris.core.common.StringPayloadDataInputParameter;
 import com.adaptris.core.common.StringPayloadDataOutputParameter;
 import com.adaptris.core.json.JsonPathExecution;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 import com.adaptris.util.text.NullToEmptyStringConverter;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
@@ -27,7 +27,7 @@ import com.jayway.jsonpath.ReadContext;
 import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 
-public class JsonPathServiceTest extends ServiceCase {
+public class JsonPathServiceTest extends ExampleServiceCase {
 
   private static final String PATH_TO_ARRAY = "$.some_integers";
   private static final String PATH_NOT_FOUND = "$.path.not.found";
@@ -55,10 +55,6 @@ public class JsonPathServiceTest extends ServiceCase {
     }
   }
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
   AdaptrisMessage createMessage() throws Exception {
     return DefaultMessageFactory.getDefaultInstance().newMessage(sampleJsonContent());
   }

--- a/src/test/java/com/adaptris/core/services/routing/json/JsonPathSyntaxIdentifierTest.java
+++ b/src/test/java/com/adaptris/core/services/routing/json/JsonPathSyntaxIdentifierTest.java
@@ -7,13 +7,13 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
 import com.adaptris.core.BranchingServiceCollection;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.services.LogMessageService;
 import com.adaptris.core.services.routing.AlwaysMatchSyntaxIdentifier;
 import com.adaptris.core.services.routing.SyntaxBranchingService;
 import com.adaptris.core.services.routing.SyntaxIdentifier;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 
-public class JsonPathSyntaxIdentifierTest extends ServiceCase {
+public class JsonPathSyntaxIdentifierTest extends ExampleServiceCase {
 
   private static final String BASE_DIR_KEY = "JsonPathServiceExamples.baseDir";
 
@@ -27,11 +27,6 @@ public class JsonPathSyntaxIdentifierTest extends ServiceCase {
   }
 
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
-  
   @Test
   public void testIsThisSyntax_Matches() throws Exception {
     JsonPathSyntaxIdentifier identifier = new JsonPathSyntaxIdentifier();

--- a/src/test/java/com/adaptris/core/services/splitter/json/BatchedJsonArraySplitterTest.java
+++ b/src/test/java/com/adaptris/core/services/splitter/json/BatchedJsonArraySplitterTest.java
@@ -13,12 +13,6 @@ import com.adaptris.interlok.util.CloseableIterable;
 
 public class BatchedJsonArraySplitterTest extends SplitterServiceExample {
 
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
-
   @Test
   public void testSetBatchSize() {
     assertNull(createSplitterForTests().getBatchSize());

--- a/src/test/java/com/adaptris/core/services/splitter/json/JsonArraySplitterTest.java
+++ b/src/test/java/com/adaptris/core/services/splitter/json/JsonArraySplitterTest.java
@@ -13,11 +13,6 @@ public class JsonArraySplitterTest extends SplitterServiceExample {
 
   private static final String SIMPLE_ARRAY = "[ \"file1\", \"file2\" , \"file3\" , \"file4\"]";
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
-
   @Test
   public void testSplitArray() throws Exception {
     JsonArraySplitter s = new JsonArraySplitter();

--- a/src/test/java/com/adaptris/core/services/splitter/json/JsonLargeArraySplitterTest.java
+++ b/src/test/java/com/adaptris/core/services/splitter/json/JsonLargeArraySplitterTest.java
@@ -13,10 +13,6 @@ import com.adaptris.interlok.util.CloseableIterable;
 public class JsonLargeArraySplitterTest extends SplitterServiceExample {
 
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
   @Test
   public void testWithBufferSize() {
     assertNull(createSplitter().getBufferSize());

--- a/src/test/java/com/adaptris/core/services/splitter/json/JsonMetadataSplitterTest.java
+++ b/src/test/java/com/adaptris/core/services/splitter/json/JsonMetadataSplitterTest.java
@@ -11,11 +11,6 @@ import com.adaptris.interlok.util.CloseableIterable;
 
 public class JsonMetadataSplitterTest extends SplitterServiceExample {
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
-
   public static final String PAYLOAD = "[\n" + "{\"colour\": \"red\"},\n" + "{\"colour\": \"green\"},\n"
       + "{\"colour\": \"blue\"},\n" + "{\"colour\": \"black\"}\n" + "]";
 

--- a/src/test/java/com/adaptris/core/services/splitter/json/JsonObjectSplitterTest.java
+++ b/src/test/java/com/adaptris/core/services/splitter/json/JsonObjectSplitterTest.java
@@ -14,11 +14,6 @@ import net.sf.json.JSONSerializer;
 
 public class JsonObjectSplitterTest extends SplitterServiceExample {
 
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
   public static final String JSON_ARRAY =
       "[\n{\"colour\": \"red\",\"value\": \"#f00\"},\n"
       + "{\"colour\": \"green\",\"value\": \"#0f0\"},\n"

--- a/src/test/java/com/adaptris/core/services/splitter/json/JsonPathSplitterTest.java
+++ b/src/test/java/com/adaptris/core/services/splitter/json/JsonPathSplitterTest.java
@@ -10,12 +10,6 @@ import com.adaptris.core.common.StringPayloadDataInputParameter;
 
 public class JsonPathSplitterTest extends SplitterServiceExample {
 
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
-  
   @Test
   public void testSplitArray() throws Exception {
     JsonPathSplitter splitter = createSplitter();
@@ -54,7 +48,7 @@ public class JsonPathSplitterTest extends SplitterServiceExample {
     splitter.setMessageSplitter(new JsonArraySplitter());
     return splitter;
   }
-  
+
   private String sampleJsonContent() {
     return "{"
     + "\"store\": {"

--- a/src/test/java/com/adaptris/core/services/splitter/json/LargeJsonArrayPathSplitterTest.java
+++ b/src/test/java/com/adaptris/core/services/splitter/json/LargeJsonArrayPathSplitterTest.java
@@ -27,11 +27,6 @@ public class LargeJsonArrayPathSplitterTest extends SplitterServiceExample {
   public static final String TWO_LAYERS_JSON_ARRAY = "{\"status\":\"ok\",\"result\":{\"colours\":[{\"colour\":\"red\",\"value\":\"#f00\"},{\"colour\":\"green\",\"value\":\"#0f0\"},{\"colour\":\"blue\",\"value\":\"#00f\"},{\"colour\":\"black\",\"value\":\"#000\"}]}}";
 
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
-
   @Test
   public void testWithPath() {
     assertNull(new LargeJsonArrayPathSplitter().getPath());

--- a/src/test/java/com/adaptris/core/services/splitter/json/SplitterServiceExample.java
+++ b/src/test/java/com/adaptris/core/services/splitter/json/SplitterServiceExample.java
@@ -5,7 +5,6 @@ import java.util.List;
 import com.adaptris.core.NullConnection;
 import com.adaptris.core.NullMessageProducer;
 import com.adaptris.core.Service;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.ServiceList;
 import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.services.WaitService;
@@ -13,8 +12,9 @@ import com.adaptris.core.services.splitter.AdvancedMessageSplitterService;
 import com.adaptris.core.services.splitter.BasicMessageSplitterService;
 import com.adaptris.core.services.splitter.MessageSplitter;
 import com.adaptris.core.services.splitter.MessageSplitterServiceImp;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 
-public abstract class SplitterServiceExample extends ServiceCase {
+public abstract class SplitterServiceExample extends ExampleServiceCase {
 
   private static final String BASE_DIR_KEY = "SplitterServiceExamples.baseDir";
 

--- a/src/test/java/com/adaptris/core/transform/json/JsonTransformServiceTest.java
+++ b/src/test/java/com/adaptris/core/transform/json/JsonTransformServiceTest.java
@@ -2,10 +2,8 @@ package com.adaptris.core.transform.json;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
-
 import org.junit.Before;
 import org.junit.Test;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConfiguredDestination;
 import com.adaptris.core.DefaultMessageFactory;
@@ -16,7 +14,7 @@ import com.adaptris.core.common.MetadataDataInputParameter;
 import com.adaptris.core.common.StringPayloadDataInputParameter;
 import com.adaptris.core.common.StringPayloadDataOutputParameter;
 import com.adaptris.core.metadata.NoOpMetadataFilter;
-import com.adaptris.core.transform.TransformServiceExample;
+import com.adaptris.interlok.junit.scaffolding.services.TransformServiceExample;
 
 public class JsonTransformServiceTest extends TransformServiceExample {
 
@@ -30,10 +28,6 @@ public class JsonTransformServiceTest extends TransformServiceExample {
 
   private AdaptrisMessage message;
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
 
   @Before
   public void setUp() throws Exception {

--- a/src/test/java/com/adaptris/core/transform/json/JsonXmlJsonTest.java
+++ b/src/test/java/com/adaptris/core/transform/json/JsonXmlJsonTest.java
@@ -81,4 +81,14 @@ public class JsonXmlJsonTest {
     assertEquals("", context.read("$.object.primary.value"));
     assertEquals("", context.read("$.object.watermark"));
   }
+
+
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testDefaultTransform() throws Exception {
+    AdaptrisMessage msg =
+        AdaptrisMessageFactory.getDefaultInstance().newMessage(JsonXmlJsonTest.JSON_INPUT);
+    new TransformationDriver() {}.transform(msg, TransformationDirection.JSON_TO_XML);
+  }
+
 }

--- a/src/test/java/com/adaptris/core/transform/json/JsonXmlJsonTest.java
+++ b/src/test/java/com/adaptris/core/transform/json/JsonXmlJsonTest.java
@@ -8,8 +8,8 @@ import org.junit.Before;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.common.ConstantDataInputParameter;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
@@ -20,9 +20,9 @@ import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 // Tests INTERLOK-1499
 public class JsonXmlJsonTest {
 
-  private static final String SAMPLE_INPUT = "{" + 
-      "\"object\": {" + 
-      "    \"primary\": {" + 
+  private static final String SAMPLE_INPUT = "{" +
+      "\"object\": {" +
+      "    \"primary\": {" +
       "        \"value\": \"\"" +
       "    }," +
       "    \"secondary\": {" +
@@ -65,9 +65,9 @@ public class JsonXmlJsonTest {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(SAMPLE_INPUT);
     JsonXmlTransformService toXml = new JsonXmlTransformService(TransformationDirection.JSON_TO_XML);
     JsonXmlTransformService toJson = new JsonXmlTransformService(TransformationDirection.XML_TO_JSON);
-    ServiceCase.execute(toXml, msg);
+    ExampleServiceCase.execute(toXml, msg);
     System.err.println(msg.getContent());
-    ServiceCase.execute(toJson, msg);
+    ExampleServiceCase.execute(toJson, msg);
     System.err.println(msg.getContent());
     ReadContext context = JsonPath.parse(msg.getInputStream(), jsonConfig);
     assertNotNull(context.read("$.object.secondary.values"));
@@ -75,7 +75,7 @@ public class JsonXmlJsonTest {
     assertEquals("", context.read("$.object.watermark"));
     JsonTransformService transform = new JsonTransformService(
         new ConstantDataInputParameter("[{\"operation\": \"com.adaptris.core.transform.json.jolt.NullToEmptyString\"}]"));
-    ServiceCase.execute(transform, msg);
+    ExampleServiceCase.execute(transform, msg);
     context = JsonPath.parse(msg.getInputStream(), jsonConfig);
     assertNotNull(context.read("$.object.secondary.values"));
     assertEquals("", context.read("$.object.primary.value"));

--- a/src/test/java/com/adaptris/core/transform/json/JsonXmlTransformServiceTest.java
+++ b/src/test/java/com/adaptris/core/transform/json/JsonXmlTransformServiceTest.java
@@ -12,8 +12,9 @@ import org.w3c.dom.Document;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.transform.TransformServiceExample;
+import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 import com.adaptris.core.util.XmlHelper;
+import com.adaptris.interlok.junit.scaffolding.services.TransformServiceExample;
 import com.adaptris.util.text.xml.XPath;
 
 public class JsonXmlTransformServiceTest extends TransformServiceExample {
@@ -58,11 +59,6 @@ public class JsonXmlTransformServiceTest extends TransformServiceExample {
           + "\"name\": \"Victoria\", " + "\"modeName\": \"tube\", " + "\"created\": \"2015-07-23T14:35:19.787\", "
           + "\"modified\": \"2015-07-23T14:35:19.787\", " + "\"lineStatuses\": [], " + "\"routeSections\": [] }]";
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
-  
   @Test
   public void testTransformToXml() throws Exception {
     final AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON_INPUT);
@@ -153,7 +149,8 @@ public class JsonXmlTransformServiceTest extends TransformServiceExample {
   }
 
   public static void doXmlAssertions(AdaptrisMessage msg) throws Exception {
-    Document d = XmlHelper.createDocument(msg);
+    Document d = XmlHelper.createDocument(msg,
+        DocumentBuilderFactoryBuilder.newInstance().withNamespaceAware(false));
     XPath xp = new XPath();
     assertEquals("Seattle", xp.selectSingleTextItem(d, "/json/entry[1]/location"));
     assertEquals("New York", xp.selectSingleTextItem(d, "/json/entry[2]/location"));

--- a/src/test/java/com/adaptris/core/transform/json/MetadataToJsonServiceTest.java
+++ b/src/test/java/com/adaptris/core/transform/json/MetadataToJsonServiceTest.java
@@ -10,28 +10,23 @@ import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.MetadataElement;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.metadata.RegexMetadataFilter;
 import com.adaptris.core.stubs.DefectiveMessageFactory;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
 
-public class MetadataToJsonServiceTest extends ServiceCase {
+public class MetadataToJsonServiceTest extends ExampleServiceCase {
 
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
 
   @Test
   public void testDoService() throws Exception {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     msg.addMetadata("key1", "ABCDE");
     msg.addMetadata("key2", "1234");
-    ServiceCase.execute(new MetadataToJsonService(), msg);
+    execute(new MetadataToJsonService(), msg);
     DocumentContext ctx = JsonPath.parse(msg.getContent());
 
     assertEquals("ABCDE", ctx.read("$.key1"));
@@ -43,7 +38,7 @@ public class MetadataToJsonServiceTest extends ServiceCase {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     msg.addMetadata("key1", "ABCDE");
     msg.addMetadata("key2", "256.368480478703");
-    ServiceCase.execute(new MetadataToJsonService().withConvertNumeric(true), msg);
+    execute(new MetadataToJsonService().withConvertNumeric(true), msg);
     DocumentContext ctx = JsonPath.parse(msg.getContent());
 
     assertEquals("ABCDE", ctx.read("$.key1"));
@@ -56,7 +51,8 @@ public class MetadataToJsonServiceTest extends ServiceCase {
     msg.addMetadata("key1", "ABCDE");
     msg.addMetadata("key2", "1234");
     msg.addMetadata("skip", "1234");
-    ServiceCase.execute(new MetadataToJsonService().withMetadataFilter(new RegexMetadataFilter().withIncludePatterns("key1", "key2")), msg);
+    execute(new MetadataToJsonService()
+        .withMetadataFilter(new RegexMetadataFilter().withIncludePatterns("key1", "key2")), msg);
     DocumentContext ctx = JsonPath.parse(msg.getContent());
 
     assertEquals("ABCDE", ctx.read("$.key1"));
@@ -74,9 +70,9 @@ public class MetadataToJsonServiceTest extends ServiceCase {
     HashSet<MetadataElement> metadata =
         new HashSet<>(Arrays.asList(new MetadataElement("key1", "ABCDE"), new MetadataElement("key2", "1234")));
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("", metadata);
-    ServiceCase.execute(new MetadataToJsonService().withAddTrailingNewline(false), msg);
+    execute(new MetadataToJsonService().withAddTrailingNewline(false), msg);
     assertFalse(msg.getContent().endsWith(System.lineSeparator()));
-    ServiceCase.execute(new MetadataToJsonService().withAddTrailingNewline(true), msg);
+    execute(new MetadataToJsonService().withAddTrailingNewline(true), msg);
     long newlineCount = msg.getContent().chars().filter(ch -> ch == '\n').count();
     assertEquals(1, newlineCount);
     assertTrue(msg.getContent().endsWith(System.lineSeparator()));
@@ -88,7 +84,7 @@ public class MetadataToJsonServiceTest extends ServiceCase {
         new HashSet<>(Arrays.asList(new MetadataElement("key1", "ABCDE"), new MetadataElement("key2", "1234")));
     AdaptrisMessage msg = new DefectiveMessageFactory(DefectiveMessageFactory.WhenToBreak.METADATA_GET).newMessage("", metadata);
     try {
-      ServiceCase.execute(new MetadataToJsonService().withAddTrailingNewline(false), msg);
+      execute(new MetadataToJsonService().withAddTrailingNewline(false), msg);
       fail();
     } catch (ServiceException expected) {
 

--- a/src/test/java/com/adaptris/core/transform/json/XStreamTransformationDriverTest.java
+++ b/src/test/java/com/adaptris/core/transform/json/XStreamTransformationDriverTest.java
@@ -4,12 +4,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import java.util.concurrent.ThreadLocalRandom;
 import org.junit.Test;
-import com.adaptris.core.BaseCase;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.SerializableAdaptrisMessage;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.XStreamJsonMarshaller;
 import com.adaptris.core.XStreamMarshaller;
+import com.adaptris.interlok.junit.scaffolding.BaseCase;
 import com.adaptris.interlok.types.SerializableMessage;
 import com.adaptris.util.GuidGenerator;
 
@@ -17,12 +17,6 @@ public class XStreamTransformationDriverTest extends BaseCase {
 
   private transient XStreamMarshaller xmlMarshaller;
   private transient XStreamJsonMarshaller jsonMarshaller;
-
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
 
   @Test
   public void testToXML() throws Exception {

--- a/src/test/java/com/adaptris/core/transform/json/YamlToJsonTest.java
+++ b/src/test/java/com/adaptris/core/transform/json/YamlToJsonTest.java
@@ -4,20 +4,14 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.transform.TransformServiceExample;
+import com.adaptris.interlok.junit.scaffolding.services.TransformServiceExample;
 
 public class YamlToJsonTest extends TransformServiceExample {
-  
+
   private static final String SAMPLE_YAML = "schemes:" + System.lineSeparator() + "- http";
   private static final String EXPECTED_JSON = "{\"schemes\":[\"http\"]}";
-  
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
-  
-  
+
   @Test
   public void testService() throws Exception {
     YamlToJsonService service = new YamlToJsonService();
@@ -25,7 +19,7 @@ public class YamlToJsonTest extends TransformServiceExample {
     execute(service, msg);
     assertEquals(EXPECTED_JSON, msg.getContent());
   }
-  
+
   @Override
   protected Object retrieveObjectForSampleConfig() {
     return new YamlToJsonService();

--- a/src/test/java/com/adaptris/core/transform/json/jolt/EmptyStringToNullTest.java
+++ b/src/test/java/com/adaptris/core/transform/json/jolt/EmptyStringToNullTest.java
@@ -2,18 +2,15 @@ package com.adaptris.core.transform.json.jolt;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-
 import java.util.EnumSet;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.common.ConstantDataInputParameter;
 import com.adaptris.core.transform.json.JsonTransformService;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
@@ -23,9 +20,9 @@ import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 
 public class EmptyStringToNullTest {
 
-  private static final String SAMPLE_INPUT = "{" + 
-      "\"object\": {" + 
-      "    \"primary\": {" + 
+  private static final String SAMPLE_INPUT = "{" +
+      "\"object\": {" +
+      "    \"primary\": {" +
       "        \"value\": \"\"" +
       "    }," +
       "    \"secondary\": {" +
@@ -56,7 +53,7 @@ public class EmptyStringToNullTest {
     ConstantDataInputParameter spec = new ConstantDataInputParameter(SPEC);
     transform.setMappingSpec(spec);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(SAMPLE_INPUT);
-    ServiceCase.execute(transform, msg);
+    ExampleServiceCase.execute(transform, msg);
     ReadContext context = JsonPath.parse(msg.getInputStream(), jsonConfig);
     assertNotNull(context.read("$.object.secondary.values"));
     assertNull(context.read("$.object.primary.value"));

--- a/src/test/java/com/adaptris/core/transform/json/jolt/NullToEmptyStringTest.java
+++ b/src/test/java/com/adaptris/core/transform/json/jolt/NullToEmptyStringTest.java
@@ -2,18 +2,15 @@ package com.adaptris.core.transform.json.jolt;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-
 import java.util.EnumSet;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.common.ConstantDataInputParameter;
 import com.adaptris.core.transform.json.JsonTransformService;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
@@ -23,9 +20,9 @@ import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 
 public class NullToEmptyStringTest {
 
-  private static final String SAMPLE_INPUT = "{" + 
-      "\"object\": {" + 
-      "    \"primary\": {" + 
+  private static final String SAMPLE_INPUT = "{" +
+      "\"object\": {" +
+      "    \"primary\": {" +
       "        \"value\": null" +
       "    }," +
       "    \"secondary\": {" +
@@ -56,7 +53,7 @@ public class NullToEmptyStringTest {
     ConstantDataInputParameter spec = new ConstantDataInputParameter(SPEC);
     transform.setMappingSpec(spec);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(SAMPLE_INPUT);
-    ServiceCase.execute(transform, msg);
+    ExampleServiceCase.execute(transform, msg);
     ReadContext context = JsonPath.parse(msg.getInputStream(), jsonConfig);
     assertNotNull(context.read("$.object.secondary.values"));
     assertEquals("", context.read("$.object.primary.value"));


### PR DESCRIPTION
## Motivation

TransformationDriver needs to change so that we aren't forced to use a strings. This means we can plugin json-streaming(stax) or otherwise as the XML/JSON transformation driver.

## Modification

- Removed use of all the deprecated BaseCase etc stuff (which was from INTERLOK-3296) (which means there are a lot of commit changes) -> don't look at the test classes ;)
- Added a `transform(AdaptrisMessage, TransformDirection)` method to TransformationDriver which is defaulted to just call the string method for backwards compatibility.
- Changed JsonXmlTransformService to use the new Message variant
- Added explicit test for the default methods...

If you want the real changes : https://github.com/adaptris/interlok-json/pull/131/commits/05060dadbca3584e47b4538de1117f15f5738500

## Result

No change until we introduce a new json-stax-transformation-driver into json-streaming

## Testing

The tests pass, so it should be good.
