### PR TITLE
INTERLOK-3424 - Implement aggregate method from interface.

### DIFF
--- a/interlok-json/src/main/java/com/adaptris/core/json/aggregator/JsonAggregatorImpl.java
+++ b/interlok-json/src/main/java/com/adaptris/core/json/aggregator/JsonAggregatorImpl.java
@@ -1,0 +1,19 @@
+package com.adaptris.core.json.aggregator;
+
+import java.util.Collection;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.services.aggregator.MessageAggregatorImpl;
+
+public abstract class JsonAggregatorImpl extends MessageAggregatorImpl {
+
+  @Override
+  public void joinMessage(AdaptrisMessage original, Collection<AdaptrisMessage> messages)
+      throws CoreException {
+    aggregate(original, messages);
+  }
+
+  @Override
+  public abstract void aggregate(AdaptrisMessage original, Iterable<AdaptrisMessage> msgs)
+      throws CoreException;
+}

--- a/interlok-json/src/main/java/com/adaptris/core/json/aggregator/JsonArrayAggregator.java
+++ b/interlok-json/src/main/java/com/adaptris/core/json/aggregator/JsonArrayAggregator.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,14 +20,10 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.Writer;
-import java.util.Collection;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.services.aggregator.MessageAggregator;
-import com.adaptris.core.services.aggregator.MessageAggregatorImpl;
 import com.adaptris.core.util.ExceptionHelper;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParseException;
@@ -35,35 +31,35 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.NoArgsConstructor;
 
 /**
  * {@link MessageAggregator} implementation that adds each message to a JSON array.
- * 
+ *
  * <p>
  * The pre-split message is always ignored; the payloads from the collection are assumed to be JSON objects, and will be aggregated
  * together as a single JSON array. Messages that are not JSON objects will be ignored (JSON Arrays will also be ignored).
  * </p>
- * 
+ *
  * @config json-array-aggregator
  * @since 3.6.5
  */
 @XStreamAlias("json-array-aggregator")
 @ComponentProfile(summary = "Aggregate multiple messages into a JSON Array", since = "3.6.5", tag = "json")
-public class JsonArrayAggregator extends MessageAggregatorImpl {
+@NoArgsConstructor
+public class JsonArrayAggregator extends JsonAggregatorImpl {
   private transient ObjectMapper mapper = new ObjectMapper();
-  private transient Logger log = LoggerFactory.getLogger(this.getClass());
-
-  public JsonArrayAggregator() {
-
-  }
 
   @Override
-  public void joinMessage(AdaptrisMessage original, Collection<AdaptrisMessage> messages) throws CoreException {
+  public void aggregate(AdaptrisMessage original, Iterable<AdaptrisMessage> messages)
+      throws CoreException {
     try (Writer w = new BufferedWriter(original.getWriter()); JsonGenerator generator = mapper.getFactory().createGenerator(w)) {
       generator.writeStartArray();
-      for (AdaptrisMessage msg : filter(messages)) {
-        write(msg, generator);
-        overwriteMetadata(msg, original);
+      for (AdaptrisMessage msg : messages) {
+        if (filter(msg)) {
+          write(msg, generator);
+          overwriteMetadata(msg, original);
+        }
       }
       generator.writeEndArray();
     }

--- a/interlok-json/src/main/java/com/adaptris/core/json/aggregator/JsonArrayArrayAggregator.java
+++ b/interlok-json/src/main/java/com/adaptris/core/json/aggregator/JsonArrayArrayAggregator.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,18 +18,13 @@ package com.adaptris.core.json.aggregator;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
-import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.services.aggregator.MessageAggregator;
-import com.adaptris.core.services.aggregator.MessageAggregatorImpl;
 import com.adaptris.core.util.ExceptionHelper;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParseException;
@@ -39,62 +34,62 @@ import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.NoArgsConstructor;
 
 /**
  * {@link MessageAggregator} implementation that adds each message to a JSON array.
- * 
+ *
  * <p>
  * The pre-split message is always ignored; the payloads from the collection are assumed to be JSON array or objects, and will be
  * aggregated together as a single JSON array. Messages that are not JSON array or objects will be ignored .
  * </p>
- * 
+ *
  * @config json-array-array-aggregator
  * @since 3.6.5
  */
 @XStreamAlias("json-array-array-aggregator")
 @ComponentProfile(summary = "Aggregate messages that are JSON Arrays.", since = "3.6.5", tag = "json")
-public class JsonArrayArrayAggregator extends MessageAggregatorImpl {
+@NoArgsConstructor
+public class JsonArrayArrayAggregator extends JsonAggregatorImpl {
   private transient ObjectMapper mapper = new ObjectMapper();
-  private transient Logger log = LoggerFactory.getLogger(this.getClass());
-
-  public JsonArrayArrayAggregator() {
-
-  }
 
   @Override
-  public void joinMessage(AdaptrisMessage original, Collection<AdaptrisMessage> messages) throws CoreException {
-    try (Writer w = new BufferedWriter(original.getWriter()); JsonGenerator generator = mapper.getFactory().createGenerator(w)) {
+  public void aggregate(AdaptrisMessage original, Iterable<AdaptrisMessage> messages)
+      throws CoreException {
+    try (Writer w = new BufferedWriter(original.getWriter());
+        JsonGenerator generator = mapper.getFactory().createGenerator(w)) {
       generator.writeStartArray();
-      for (AdaptrisMessage msg : filter(messages)) {
-        write(msg, generator);
-        overwriteMetadata(msg, original);
+      for (AdaptrisMessage msg : messages) {
+        if (filter(msg)) {
+          write(msg, generator);
+          overwriteMetadata(msg, original);
+        }
       }
       generator.writeEndArray();
-    }
-    catch (Exception e) {
+    } catch (Exception e) {
       throw ExceptionHelper.wrapCoreException(e);
     }
   }
 
 
-  private void write(final AdaptrisMessage msg, JsonGenerator generator) throws IOException {
+  private void write(final AdaptrisMessage msg, JsonGenerator generator) throws Exception {
     try (BufferedReader buf = new BufferedReader(msg.getReader())) {
       JsonParser parser = mapper.getFactory().createParser(buf);
       JsonToken nextToken = parser.nextToken();
       if (nextToken == JsonToken.START_OBJECT) {
         generator.writeTree(mapper.readTree(parser));
-      } else if(nextToken == JsonToken.START_ARRAY){
-        List<TreeNode> nodes = mapper.readValue(parser, mapper.getTypeFactory().constructCollectionType(ArrayList.class, ObjectNode.class));
-        for(TreeNode node : nodes){
+
+      }
+      if (nextToken == JsonToken.START_ARRAY) {
+        List<TreeNode> nodes = mapper.readValue(parser,
+            mapper.getTypeFactory().constructCollectionType(ArrayList.class, ObjectNode.class));
+        for (TreeNode node : nodes) {
           generator.writeTree(node);
         }
-      } else {
-        log.trace("Ignoring [{}], not JSON object", msg.getUniqueId());
       }
     } catch (JsonParseException e) {
       // ignore it.
     }
     return;
   }
-
 }

--- a/interlok-json/src/main/java/com/adaptris/core/json/aggregator/JsonMergeAggregator.java
+++ b/interlok-json/src/main/java/com/adaptris/core/json/aggregator/JsonMergeAggregator.java
@@ -3,19 +3,22 @@ package com.adaptris.core.json.aggregator;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.Writer;
-import java.util.Collection;
+import javax.validation.constraints.NotBlank;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.services.aggregator.MessageAggregator;
-import com.adaptris.core.services.aggregator.MessageAggregatorImpl;
 import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.interlok.util.Args;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * {@link MessageAggregator} implementation that merges each message to a JSON object or array.
@@ -29,12 +32,22 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("json-merge-aggregator")
 @ComponentProfile(summary = "Merge each message into an existing JSON object.", tag = "json")
-public class JsonMergeAggregator extends MessageAggregatorImpl {
+@NoArgsConstructor
+public class JsonMergeAggregator extends JsonAggregatorImpl {
   protected transient ObjectMapper mapper = new ObjectMapper();
-  protected String mergeMetadataKey;
+  /**
+   * Specify the metadata key that contains the 'key' against which the message will be merged into
+   * the original.
+   *
+   */
+  @Getter
+  @Setter
+  @NotBlank
+  private String mergeMetadataKey;
 
   @Override
-  public void joinMessage(AdaptrisMessage original, Collection<AdaptrisMessage> messages) throws CoreException {
+  public void aggregate(AdaptrisMessage original, Iterable<AdaptrisMessage> messages)
+      throws CoreException {
     JsonNode rootNode;
     try {
       rootNode = mapper.readTree(original.getContent());
@@ -43,14 +56,17 @@ public class JsonMergeAggregator extends MessageAggregatorImpl {
     }
 
     try (Writer w = new BufferedWriter(original.getWriter()); JsonGenerator generator = mapper.getFactory().createGenerator(w)) {
-      for (AdaptrisMessage msg : filter(messages)) {
-        final String mergeKeyName = msg.getMetadataValue(mergeMetadataKey);
-        try {
-          mergeChildEntryIntoParent(rootNode, mergeKeyName, msg);
-          overwriteMetadata(msg, original);
-        } catch (CoreException ce) {
-          // log error and continue with the remaining msgs
-          log.error("Failed to merge the following message: [{}] into parent payload", mergeKeyName);
+      for (AdaptrisMessage msg : messages) {
+        if (filter(msg)) {
+          try {
+            final String mergeKeyName =
+                Args.notBlank(msg.getMetadataValue(getMergeMetadataKey()), "merge-key-name");
+            mergeChildEntryIntoParent(rootNode, mergeKeyName, msg);
+            overwriteMetadata(msg, original);
+          } catch (Exception ce) {
+            log.error("Failed to merge the following message: [{}] into parent payload",
+                msg.getUniqueId());
+          }
         }
       }
       generator.writeTree(rootNode);
@@ -77,14 +93,6 @@ public class JsonMergeAggregator extends MessageAggregatorImpl {
     else {
       throw new CoreException("Unable to merge into unknown json type");
     }
-  }
-
-  public String getMergeMetadataKey() {
-    return mergeMetadataKey;
-  }
-
-  public void setMergeMetadataKey(String mergeMetadataKey) {
-    this.mergeMetadataKey = mergeMetadataKey;
   }
 
 }

--- a/interlok-json/src/test/java/com/adaptris/core/json/aggregator/JsonArrayAggregatorFilterTest.java
+++ b/interlok-json/src/test/java/com/adaptris/core/json/aggregator/JsonArrayAggregatorFilterTest.java
@@ -3,18 +3,16 @@ package com.adaptris.core.json.aggregator;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-
 import org.apache.commons.io.IOUtils;
 import org.json.JSONArray;
 import org.junit.Test;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.Service;
 import com.adaptris.core.json.JsonToMetadata;
 import com.adaptris.core.services.conditional.conditions.ConditionMetadata;
 import com.adaptris.core.services.conditional.operator.Equals;
-import com.adaptris.core.services.splitter.SplitJoinService;
+import com.adaptris.core.services.splitter.PooledSplitJoinService;
 import com.adaptris.core.services.splitter.json.JsonArraySplitter;
 import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 
@@ -27,8 +25,8 @@ public class JsonArrayAggregatorFilterTest extends ExampleServiceCase {
 
 
   @Override
-  protected Object retrieveObjectForSampleConfig() {
-    SplitJoinService service = new SplitJoinService();
+  protected PooledSplitJoinService retrieveObjectForSampleConfig() {
+    PooledSplitJoinService service = new PooledSplitJoinService();
     service.setService(new JsonToMetadata());
     service.setSplitter(new JsonArraySplitter());
 
@@ -53,7 +51,7 @@ public class JsonArrayAggregatorFilterTest extends ExampleServiceCase {
 
     // Create AdaptrisMessage and the SplitJoinService
     AdaptrisMessage original = AdaptrisMessageFactory.getDefaultInstance().newMessage(fileContents);
-    final Service service = (Service) retrieveObjectForSampleConfig();
+    final Service service = retrieveObjectForSampleConfig();
 
     // run
     execute(service, original);
@@ -80,7 +78,7 @@ public class JsonArrayAggregatorFilterTest extends ExampleServiceCase {
 
     // Create AdaptrisMessage and the SplitJoinService
     AdaptrisMessage original = AdaptrisMessageFactory.getDefaultInstance().newMessage(fileContents);
-    final SplitJoinService service = (SplitJoinService) retrieveObjectForSampleConfig();
+    final PooledSplitJoinService service = retrieveObjectForSampleConfig();
     ((JsonArrayAggregator)service.getAggregator()).setFilterCondition(null);
 
     // run


### PR DESCRIPTION
## Motivation

Because of https://github.com/adaptris/interlok/pull/524 there is a new aggregate() method that works on Iterable rather than Collections (for lazy iteration with large messages / joins).

The various JSON aggregators should support this rather than relying on the default behaviour which doesn't change the performance characteristics.

c.f. : https://github.com/adaptris/interlok-csv/pull/88

## Modification

- Directly implement aggregate() method that is now defined in MessageAggregator.  
- joinMessage() delegates to it
- Change branching logic in JsonArrayArrayAggregator for coverage purposes, we can't fire the else condition; since if it's not json it will throw a JsonParseException.
- More tests.

## Result

No visible change for the user.

## Testing

Unit tests pass and any existing configuration should work.
