### PR TITLE
INTERLOK-3484 - Remove duplicate messages

### DIFF
--- a/interlok-json/src/main/java/com/adaptris/core/json/schema/ModifyPayloadExceptionHandler.java
+++ b/interlok-json/src/main/java/com/adaptris/core/json/schema/ModifyPayloadExceptionHandler.java
@@ -2,11 +2,13 @@ package com.adaptris.core.json.schema;
 
 import java.io.IOException;
 import java.io.Writer;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
+
 import org.everit.json.schema.ValidationException;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.InputFieldDefault;
@@ -55,13 +57,10 @@ public class ModifyPayloadExceptionHandler extends ValidationExceptionHandlerImp
   public void handle(ValidationException exc, AdaptrisMessage msg) throws ServiceException {
     try {
       Object json = jsonify(msg.getContent());
-      ArrayList<String> violations = new ArrayList<>();
+      Set<String> violations = new LinkedHashSet<>();
       violations.add(exc.getMessage());
-      List<String> allMessages = exc.getAllMessages();
-      if (allMessages.size() > 1) {
-        for (String ve : allMessages) {
-          violations.add(ve);
-        }
+      for (String ve : exc.getAllMessages()) {
+        violations.add(ve);
       }
       Map<String, Object> newMsg = new HashMap<>();
       newMsg.put("original", json);

--- a/interlok-json/src/main/java/com/adaptris/core/json/schema/ModifyPayloadExceptionHandler.java
+++ b/interlok-json/src/main/java/com/adaptris/core/json/schema/ModifyPayloadExceptionHandler.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.everit.json.schema.ValidationException;
 import com.adaptris.annotation.AdvancedConfig;
@@ -56,8 +57,11 @@ public class ModifyPayloadExceptionHandler extends ValidationExceptionHandlerImp
       Object json = jsonify(msg.getContent());
       ArrayList<String> violations = new ArrayList<>();
       violations.add(exc.getMessage());
-      for (String ve : exc.getAllMessages()) {
-        violations.add(ve);
+      List<String> allMessages = exc.getAllMessages();
+      if (allMessages.size() > 1) {
+        for (String ve : allMessages) {
+          violations.add(ve);
+        }
       }
       Map<String, Object> newMsg = new HashMap<>();
       newMsg.put("original", json);

--- a/interlok-json/src/test/java/com/adaptris/core/json/schema/JsonSchemaServiceTest.java
+++ b/interlok-json/src/test/java/com/adaptris/core/json/schema/JsonSchemaServiceTest.java
@@ -1,11 +1,16 @@
 package com.adaptris.core.json.schema;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
+
+import net.minidev.json.JSONArray;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -38,6 +43,7 @@ public class JsonSchemaServiceTest extends TransformServiceExample {
 
   private static final String VALID_JSON = "{ \"rectangle\" : { \"a\" : 5, \"b\" : 5 } }";
   private static final String INVALID_JSON = "{ \"rectangle\" : { \"a\" : -5, \"b\" : -5 } }";
+  private static final String SLIGHTLY_INVALID_JSON = "{ \"rectangle\" : { \"a\" : -5, \"b\" : 5 } }";
   private static final String JSON_ARRAY = "[{ \"rectangle\" : { \"a\" : 5, \"b\" : 5 } }]";
   private static final String INVALID_JSON_ARRAY = "[{ \"rectangle\" : { \"a\" : -5, \"b\" : -5 } }]";
   private static final String INVALID_JSON_STRICT = "{ \"rectangle\" : value }";
@@ -288,6 +294,15 @@ public class JsonSchemaServiceTest extends TransformServiceExample {
           .mappingProvider(new JacksonMappingProvider()).options(EnumSet.noneOf(Option.class)).build();
     ReadContext context = JsonPath.parse(msg.getInputStream(), jsonConfig);
     assertNotNull(context.read("$.original"));
-    assertNotNull(context.read("$.schema-violations"));
+
+    JSONArray violations = context.read("$.schema-violations");
+    assertNotNull(violations);
+    Set<String> messages = new HashSet<>();
+    for (Object o : violations.toArray())
+    {
+      messages.add(o.toString());
+    }
+    // make sure there are no duplicates (INTERLOK-3484)
+    assertEquals(violations.size(), messages.size());
   }
 }


### PR DESCRIPTION
## Motivation

If there is only a single violation in the input JSON, there are duplicate error messages in the response [as ```.getAllMessages()``` returns the same as ```.getMessage()```]

## Modification

If there is only 1 item returned from ```.getAllMessages()``` then ignore it, as it will be the same as returned by ```.getMessage()```.

## Result

The result is that there are not duplicate error messages.

## Testing

The update to ```JsonSchemaServiceTest.assertModifications(…)``` confirmed that duplicates were present and and now no longer included.
