### PR TITLE
INTERLOK-3427 Add JSON_LINES / JSON_ARRAY transform capability

### DIFF
--- a/interlok-json/src/main/java/com/adaptris/core/services/splitter/json/JsonProvider.java
+++ b/interlok-json/src/main/java/com/adaptris/core/services/splitter/json/JsonProvider.java
@@ -3,7 +3,7 @@ package com.adaptris.core.services.splitter.json;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.services.splitter.LineCountSplitter;
-import com.adaptris.core.util.CloseableIterable;
+import com.adaptris.interlok.util.CloseableIterable;
 
 /**
  * Allows switching between JSON arrays and JSON lines when attempting to split a payload.
@@ -49,7 +49,7 @@ public interface JsonProvider {
      * <p>
      * Under the covers it uses a {@link LineCountSplitter} to iterate over each line, ignoring blank lines.
      * </p>
-     */    
+     */
     // JSON_LINES is basically a line count splitter, where a JSON object is prsent on each line...
     // see jsonlines.org
     JSON_LINES {

--- a/interlok-json/src/main/java/com/adaptris/core/transform/json/JsonArrayToJsonLines.java
+++ b/interlok-json/src/main/java/com/adaptris/core/transform/json/JsonArrayToJsonLines.java
@@ -1,0 +1,66 @@
+package com.adaptris.core.transform.json;
+
+import static com.adaptris.interlok.util.CloseableIterable.ensureCloseable;
+import java.io.PrintWriter;
+import java.util.Map;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.ServiceImp;
+import com.adaptris.core.json.JsonUtil;
+import com.adaptris.core.services.splitter.json.JsonProvider;
+import com.adaptris.core.services.splitter.json.JsonProvider.JsonObjectProvider;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.core.util.LoggingHelper;
+import com.adaptris.interlok.util.CloseableIterable;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.NoArgsConstructor;
+
+/**
+ * Transform from a JSON Array to JSON lines.
+ *
+ * @config json-array-to-json-lines
+ */
+@XStreamAlias("json-array-to-json-lines")
+@ComponentProfile(summary = "Transform from a JSON Array to JSON lines", tag = "json,transform",
+    since = "3.11.1")
+@NoArgsConstructor
+public class JsonArrayToJsonLines extends ServiceImp {
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    ObjectMapper mapper = new ObjectMapper();
+    JsonObjectProvider jsonProvider = JsonProvider.JsonStyle.JSON_ARRAY;
+    try {
+      log.trace("Beginning doService in {}", LoggingHelper.friendlyName(this));
+      try (CloseableIterable<AdaptrisMessage> jsonObjects =  ensureCloseable(jsonProvider.createIterator(msg));
+          PrintWriter pw = new PrintWriter(msg.getWriter())) {
+
+        for (AdaptrisMessage m : jsonObjects) {
+          Map<String, String> json = JsonUtil.mapifyJson(m);
+          String line = mapper.writeValueAsString(json);
+          pw.println(line);
+        }
+
+      }
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapServiceException(e);
+    }
+  }
+
+  @Override
+  public void prepare() throws CoreException {
+  }
+
+  @Override
+  protected void initService() throws CoreException {
+  }
+
+  @Override
+  protected void closeService() {
+  }
+
+
+}

--- a/interlok-json/src/main/java/com/adaptris/core/transform/json/JsonArrayToJsonLines.java
+++ b/interlok-json/src/main/java/com/adaptris/core/transform/json/JsonArrayToJsonLines.java
@@ -21,9 +21,9 @@ import lombok.NoArgsConstructor;
 /**
  * Transform from a JSON Array to JSON lines.
  *
- * @config json-array-to-json-lines
+ * @config json-array-to-lines-transform
  */
-@XStreamAlias("json-array-to-json-lines")
+@XStreamAlias("json-array-to-lines-transform")
 @ComponentProfile(summary = "Transform from a JSON Array to JSON lines", tag = "json,transform",
     since = "3.11.1")
 @NoArgsConstructor

--- a/interlok-json/src/main/java/com/adaptris/core/transform/json/JsonLinesToJsonArray.java
+++ b/interlok-json/src/main/java/com/adaptris/core/transform/json/JsonLinesToJsonArray.java
@@ -1,0 +1,67 @@
+package com.adaptris.core.transform.json;
+
+import static com.adaptris.interlok.util.CloseableIterable.ensureCloseable;
+import java.io.Writer;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.ServiceImp;
+import com.adaptris.core.json.JsonUtil;
+import com.adaptris.core.services.splitter.json.JsonProvider;
+import com.adaptris.core.services.splitter.json.JsonProvider.JsonObjectProvider;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.core.util.LoggingHelper;
+import com.adaptris.interlok.util.CloseableIterable;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.NoArgsConstructor;
+
+/**
+ * Transform from JSON lines to a JSON Array
+ *
+ * @config json-lines-to-json-array
+ */
+@XStreamAlias("json-lines-to-json-array")
+@ComponentProfile(summary = "Transform from JSON lines to a JSON Array", tag = "json,transform",
+    since = "3.11.1")
+@NoArgsConstructor
+public class JsonLinesToJsonArray extends ServiceImp {
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    ObjectMapper mapper = new ObjectMapper();
+    JsonObjectProvider jsonProvider = JsonProvider.JsonStyle.JSON_LINES;
+    try {
+      log.trace("Beginning doService in {}", LoggingHelper.friendlyName(this));
+      try (CloseableIterable<AdaptrisMessage> jsonObjects = ensureCloseable(jsonProvider.createIterator(msg));
+          Writer w = msg.getWriter();
+          JsonGenerator generator =  mapper.getFactory().createGenerator(w).useDefaultPrettyPrinter()) {
+
+        generator.writeStartArray();
+        for (AdaptrisMessage m : jsonObjects) {
+          generator.writeObject(JsonUtil.mapifyJson(m));
+        }
+        generator.writeEndArray();
+
+      }
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapServiceException(e);
+    }
+  }
+
+  @Override
+  public void prepare() throws CoreException {
+  }
+
+  @Override
+  protected void initService() throws CoreException {
+  }
+
+  @Override
+  protected void closeService() {
+  }
+
+
+}

--- a/interlok-json/src/main/java/com/adaptris/core/transform/json/JsonLinesToJsonArray.java
+++ b/interlok-json/src/main/java/com/adaptris/core/transform/json/JsonLinesToJsonArray.java
@@ -21,9 +21,9 @@ import lombok.NoArgsConstructor;
 /**
  * Transform from JSON lines to a JSON Array
  *
- * @config json-lines-to-json-array
+ * @config json-lines-to-array-transform
  */
-@XStreamAlias("json-lines-to-json-array")
+@XStreamAlias("json-lines-to-array-transform")
 @ComponentProfile(summary = "Transform from JSON lines to a JSON Array", tag = "json,transform",
     since = "3.11.1")
 @NoArgsConstructor

--- a/interlok-json/src/test/java/com/adaptris/core/transform/json/JsonArrayToJsonLinesTest.java
+++ b/interlok-json/src/test/java/com/adaptris/core/transform/json/JsonArrayToJsonLinesTest.java
@@ -1,0 +1,12 @@
+package com.adaptris.core.transform.json;
+
+import com.adaptris.interlok.junit.scaffolding.services.TransformServiceExample;
+
+public class JsonArrayToJsonLinesTest extends TransformServiceExample {
+
+  @Override
+  protected JsonArrayToJsonLines retrieveObjectForSampleConfig() {
+    return new JsonArrayToJsonLines();
+  }
+
+}

--- a/interlok-json/src/test/java/com/adaptris/core/transform/json/JsonLinesTest.java
+++ b/interlok-json/src/test/java/com/adaptris/core/transform/json/JsonLinesTest.java
@@ -1,0 +1,96 @@
+package com.adaptris.core.transform.json;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import java.io.Reader;
+import java.util.EnumSet;
+import java.util.List;
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.ServiceException;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.ReadContext;
+import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+
+public class JsonLinesTest {
+
+  public static final String JSON_ARRAY =
+      "[\n{\"colour\": \"red\",\"value\": \"#f00\"},\n"
+      + "{\"colour\": \"green\",\"value\": \"#0f0\"},\n"
+      + "{\"colour\": \"blue\",\"value\": \"#00f\"},"
+      + "\n{\"colour\": \"black\",\"value\": \"#000\"}\n"
+      + "]";
+
+  public static final String JSON_LINES =
+      "{\"colour\": \"red\",\"value\": \"#f00\"}\n"
+      + "{\"colour\": \"green\",\"value\": \"#0f0\"}\n"
+      + "{\"colour\": \"blue\",\"value\": \"#00f\"}\n"
+      + "{\"colour\": \"black\",\"value\": \"#000\"}";
+
+  private Configuration jsonConfig;
+
+  @Before
+  public void setUp() {
+    jsonConfig = new Configuration.ConfigurationBuilder().jsonProvider(new JsonSmartJsonProvider())
+        .mappingProvider(new JacksonMappingProvider()).options(EnumSet.noneOf(Option.class))
+        .build();
+
+  }
+
+  @Test
+  public void testJsonLines_JsonArray() throws Exception {
+    JsonLinesToJsonArray service = new JsonLinesToJsonArray();
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON_LINES);
+    ExampleServiceCase.execute(service, msg);
+    assertNotEquals(JSON_LINES, msg.getContent());
+    // System.err.println(msg.getContent());
+    assertTrue(msg.getContent().startsWith("["));
+    ReadContext context = JsonPath.parse(msg.getContent(), jsonConfig);
+    assertEquals("red", context.read("$[0].colour"));
+    assertEquals("green", context.read("$[1].colour"));
+    assertEquals("blue", context.read("$[2].colour"));
+    assertEquals("black", context.read("$[3].colour"));
+  }
+
+  @Test(expected = ServiceException.class)
+  public void testJsonLines_NotJson() throws Exception {
+    JsonLinesToJsonArray service = new JsonLinesToJsonArray();
+    AdaptrisMessage msg =
+        AdaptrisMessageFactory.getDefaultInstance().newMessage("hello world\nhello world");
+    ExampleServiceCase.execute(service, msg);
+  }
+
+
+  @Test
+  public void testJsonArray_JsonLines() throws Exception {
+    JsonArrayToJsonLines service = new JsonArrayToJsonLines();
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON_ARRAY);
+    ExampleServiceCase.execute(service, msg);
+    assertNotEquals(JSON_ARRAY, msg.getContent());
+    // System.err.println(msg.getContent());
+    try (Reader r = msg.getReader()) {
+      List<String> lines = IOUtils.readLines(r);
+      assertEquals(4, lines.size());
+      assertEquals("red", JsonPath.parse(lines.get(0), jsonConfig).read("$.colour"));
+      assertEquals("green", JsonPath.parse(lines.get(1), jsonConfig).read("$.colour"));
+      assertEquals("blue", JsonPath.parse(lines.get(2), jsonConfig).read("$.colour"));
+      assertEquals("black", JsonPath.parse(lines.get(3), jsonConfig).read("$.colour"));
+    }
+  }
+
+  @Test(expected = ServiceException.class)
+  public void testJsonArray_NotJson() throws Exception {
+    JsonArrayToJsonLines service = new JsonArrayToJsonLines();
+    AdaptrisMessage msg =
+        AdaptrisMessageFactory.getDefaultInstance().newMessage("hello world\nhello world");
+    ExampleServiceCase.execute(service, msg);
+  }
+}

--- a/interlok-json/src/test/java/com/adaptris/core/transform/json/JsonLinesToJsonArrayTest.java
+++ b/interlok-json/src/test/java/com/adaptris/core/transform/json/JsonLinesToJsonArrayTest.java
@@ -1,0 +1,12 @@
+package com.adaptris.core.transform.json;
+
+import com.adaptris.interlok.junit.scaffolding.services.TransformServiceExample;
+
+public class JsonLinesToJsonArrayTest extends TransformServiceExample {
+
+  @Override
+  protected JsonLinesToJsonArray retrieveObjectForSampleConfig() {
+    return new JsonLinesToJsonArray();
+  }
+
+}


### PR DESCRIPTION
## Motivation

JSON_LINES is a thing
JSON-ARRAY is a thing

we need to be able to transform between the 2.

## Modification

- Add a JsonLinesToJsonArray service
- Add a JsonArrayToJsonLines service

Since `-array` is special to XStream; we can't have an XStreamAlias that ends with -array; so the aliases of the classes don't necessarily "match" the service name.

## Result

New services that are available to configure.

## Testing

```
<json-array-to-lines-transform/>
<json-lines-to-array-transform/>
```

Should give you "semantically similar" output.
