### PR TITLE
INTERLOK-3555 Update the pom url to point to the right doc page

### DIFF
--- a/interlok-json/build.gradle
+++ b/interlok-json/build.gradle
@@ -88,7 +88,7 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "Everything JSON related; transformations, schemas, json-path (xpath-alike), splitting")
-        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/cookbook-json-transform.html")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/cookbook/cookbook-json-transform")
         def properties = asNode().appendNode("properties")
         properties.appendNode("target", "3.8.0+")
         properties.appendNode("tags", "json,transform,jdbc")


### PR DESCRIPTION
## Motivation

The documentation was broken since we changed the doc site

## Modification

Fix the doc url

## Result

The pom has a correct doc url

## Testing

Check that the new url exists in the interlok-json POM file after running gradle generatePomFileForMavenJavaPublication.
