### PR TITLE
INTERLOK-2963 #comment Upgrade Derby DB to 10.15.2.0

### DIFF
--- a/interlok-json/build.gradle
+++ b/interlok-json/build.gradle
@@ -32,7 +32,8 @@ dependencies {
   compile ("com.google.guava:guava:30.1-jre")
   compile ("com.flipkart.zjsonpatch:zjsonpatch:0.4.11")
   testCompile ("org.skyscreamer:jsonassert:1.5.0")
-  testCompile ("org.apache.derby:derby:10.14.2.0")
+  testCompile ("org.apache.derby:derby:10.15.2.0")
+  testCompile ("org.apache.derby:derbytools:10.15.2.0")
 }
 
 jar {


### PR DESCRIPTION
## Motivation

Use the latest derby version that integrates better with java11

## Modification

Upgrade derby to 10.15.2.0

## Result

Nothing should change on how Interlok json works

## Testing

Tests should pass