### PR TITLE
INTERLOK-3567 Add resolveObject method to test object

### DIFF
--- a/interlok-json/src/test/java/com/adaptris/core/json/resolver/FromPayloadUsingJSONPathTest.java
+++ b/interlok-json/src/test/java/com/adaptris/core/json/resolver/FromPayloadUsingJSONPathTest.java
@@ -50,6 +50,7 @@ public class FromPayloadUsingJSONPathTest
     @Override public Map<Object, Object> getObjectHeaders() { return null; }
     @Override public boolean headersContainsKey(String key) { return false; }
     @Override public String resolve(String s, boolean multiline) { return null; }
+    @Override public Object resolveObject(String s) { return null; }
 
     private String payload = DATA;
     private String encoding = "UTF-8";


### PR DESCRIPTION
## Motivation

Following the merge of [interlok-3567](https://github.com/adaptris/interlok/pull/621) there was a knock-on effect. In this instance it was an anonymous instance of AdaptrisMessage in a unit test missing a new method `resolveObject(String)`.

## Modification

Add new `resolveObject(String)` method to test object.

## Result

The test will now compile and execute as expected.

## Testing

Run the unit tests `gradle build`
