### PR TITLE
INTERLOK-3333 JsonPath on large JSON (streaming)

### DIFF
--- a/interlok-json-streaming/build.gradle
+++ b/interlok-json-streaming/build.gradle
@@ -14,7 +14,10 @@ dependencies {
 
   compile("com.github.jsurfer:jsurfer-gson:$jsonSurferVersion")
   compile("com.github.jsurfer:jsurfer-jackson:$jsonSurferVersion")
-  compile("com.github.jsurfer:jsurfer-fastjson:$jsonSurferVersion")
+  compile("com.github.jsurfer:jsurfer-fastjson:$jsonSurferVersion") {
+    exclude group: "com.alibaba", module: "fastjson"
+  }
+  compile("com.alibaba:fastjson:1.2.69")
   compile("com.github.jsurfer:jsurfer-jsonsimple:$jsonSurferVersion")
 
   testCompile("org.skyscreamer:jsonassert:1.5.0")

--- a/interlok-json-streaming/build.gradle
+++ b/interlok-json-streaming/build.gradle
@@ -3,6 +3,7 @@ ext {
   componentName='Interlok Transform/JSON Streaming'
   componentDesc="Streaming JSON in a STaX-alike manner"
   jacksonVersion='2.12.3'
+  jsonSurferVersion="1.6.0"
 }
 
 
@@ -10,6 +11,11 @@ dependencies {
   compile project(':interlok-json')
   compile ("com.adaptris:interlok-stax:$interlokCoreVersion") { changing= true}
   compile ("de.odysseus.staxon:staxon:1.3")
+
+  compile("com.github.jsurfer:jsurfer-gson:$jsonSurferVersion")
+  compile("com.github.jsurfer:jsurfer-jackson:$jsonSurferVersion")
+  compile("com.github.jsurfer:jsurfer-fastjson:$jsonSurferVersion")
+  compile("com.github.jsurfer:jsurfer-jsonsimple:$jsonSurferVersion")
 
   testCompile("org.skyscreamer:jsonassert:1.5.0")
   testCompile ("com.jayway.jsonpath:json-path:2.4.0")

--- a/interlok-json-streaming/src/main/java/com/adaptris/core/json/streaming/JsonPathStreamingService.java
+++ b/interlok-json-streaming/src/main/java/com/adaptris/core/json/streaming/JsonPathStreamingService.java
@@ -17,7 +17,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
-import org.apache.commons.lang.ObjectUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.jsfr.json.Collector;
 import org.jsfr.json.JsonSurfer;
 import org.jsfr.json.JsonSurferFastJson;
@@ -234,7 +234,7 @@ public class JsonPathStreamingService extends JsonPathServiceImpl
   }
 
   private Surfer surfer() {
-    return (Surfer)ObjectUtils.defaultIfNull(surfer, Surfer.SIMPLE);
+    return ObjectUtils.defaultIfNull(surfer, Surfer.SIMPLE);
   }
 
   public enum Surfer {

--- a/interlok-json-streaming/src/main/java/com/adaptris/core/json/streaming/JsonPathStreamingService.java
+++ b/interlok-json-streaming/src/main/java/com/adaptris/core/json/streaming/JsonPathStreamingService.java
@@ -1,0 +1,144 @@
+package com.adaptris.core.json.streaming;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.common.Execution;
+import com.adaptris.core.services.path.json.JsonPathService;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.interlok.config.DataInputParameter;
+import com.adaptris.interlok.config.DataOutputParameter;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+import org.apache.commons.lang.ObjectUtils;
+import org.jsfr.json.Collector;
+import org.jsfr.json.JsonSurfer;
+import org.jsfr.json.JsonSurferFastJson;
+import org.jsfr.json.JsonSurferGson;
+import org.jsfr.json.JsonSurferJackson;
+import org.jsfr.json.JsonSurferJsonSimple;
+import org.jsfr.json.ValueBox;
+
+import javax.json.JsonException;
+import javax.validation.constraints.NotNull;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@XStreamAlias("json-path-streaming-service")
+@AdapterComponent
+@ComponentProfile(summary = "Extract a value from a large JSON document", tag = "service,transform,json,metadata,streaming,large")
+@DisplayOrder(order = {"surfer", "source", "executions", "unwrapJson"})
+@NoArgsConstructor
+public class JsonPathStreamingService extends JsonPathService {
+
+  @Getter
+  @Setter
+  @NonNull
+  @NotNull
+  private Surfer surfer;
+
+  private transient JsonSurfer jsonSurfer;
+
+  public JsonPathStreamingService(DataInputParameter<InputStream> source, Execution... executions) {
+    this(source, new ArrayList<>(Arrays.asList(executions)));
+  }
+
+  public JsonPathStreamingService(DataInputParameter<InputStream> source, List<Execution> executions) {
+    this();
+    setSource(source);
+    setExecutions(executions);
+  }
+
+  /**
+   * {@inheritDoc}.
+   */
+  @Override
+  public void doService(final AdaptrisMessage message) throws ServiceException {
+    try {
+
+      final DataInputParameter<InputStream> src = source;
+      final InputStream rawJson = src.extract(message);
+
+      final Collector collector = jsonSurfer.collector(rawJson);
+      final Map<Execution, ValueBox<Collection<Object>>> valueBoxes = new LinkedHashMap<>();
+
+      for (final Execution execution : executions) {
+        final DataInputParameter<String> source = execution.getSource();
+        final String jsonPath = source.extract(message);
+
+        ValueBox<Collection<Object>> v = collector.collectAll(jsonPath);
+        valueBoxes.put(execution, v);
+      }
+
+      collector.exec();
+
+      for (final Execution execution : valueBoxes.keySet()) {
+        final DataOutputParameter<String> target = execution.getTarget();
+        final ValueBox<Collection<Object>> valueBox = valueBoxes.get(execution);
+
+        Collection<Object> objects = valueBox.get();
+        if (objects.size() == 0) {
+          if (!suppressPathNotFound(execution)) {
+            String jsonPath = execution.getSource().extract(message);
+            throw new JsonException("Path [" + jsonPath + "] not found");
+          }
+          continue;
+        }
+        Object json = objects.size() == 1 ? objects.toArray()[0] : objects;
+        String jsonString = toString(json, execution);
+        String unwrapped = unwrap(jsonString, unwrapJson());
+        target.insert(unwrapped, message);
+      }
+
+    } catch (Throwable e) {
+      throw ExceptionHelper.wrapServiceException(e);
+    }
+  }
+
+  @Override
+  public void prepare() {
+    jsonSurfer = surfer().getInstance();
+  }
+
+  private Surfer surfer() {
+    return (Surfer)ObjectUtils.defaultIfNull(surfer, Surfer.SIMPLE);
+  }
+
+  public enum Surfer {
+    GSON {
+      @Override
+      JsonSurfer getInstance() {
+        return JsonSurferGson.INSTANCE;
+      }
+    },
+    JACKSON {
+      @Override
+      JsonSurfer getInstance() {
+        return JsonSurferJackson.INSTANCE;
+      }
+    },
+    SIMPLE {
+      @Override
+      JsonSurfer getInstance() {
+        return JsonSurferJsonSimple.INSTANCE;
+      }
+    },
+    FAST {
+      @Override
+      JsonSurfer getInstance() {
+        return JsonSurferFastJson.INSTANCE;
+      }
+    };
+    abstract JsonSurfer getInstance();
+  }
+}

--- a/interlok-json-streaming/src/test/java/com/adaptris/core/json/streaming/JsonPathStreamingServiceTest.java
+++ b/interlok-json-streaming/src/test/java/com/adaptris/core/json/streaming/JsonPathStreamingServiceTest.java
@@ -1,0 +1,433 @@
+package com.adaptris.core.json.streaming;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.common.ConstantDataInputParameter;
+import com.adaptris.core.common.Execution;
+import com.adaptris.core.common.MetadataDataInputParameter;
+import com.adaptris.core.common.MetadataDataOutputParameter;
+import com.adaptris.core.common.MetadataStreamInputParameter;
+import com.adaptris.core.common.PayloadStreamInputParameter;
+import com.adaptris.core.common.StringPayloadDataOutputParameter;
+import com.adaptris.core.json.JsonPathExecution;
+import com.adaptris.core.services.path.json.JsonPathService;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
+import com.adaptris.util.text.NullToEmptyStringConverter;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import org.jsfr.json.Collector;
+import org.jsfr.json.JsonSurferFastJson;
+import org.jsfr.json.JsonSurferGson;
+import org.jsfr.json.JsonSurferJsonSimple;
+import org.jsfr.json.ValueBox;
+import org.jsfr.json.exception.JsonSurfingException;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class JsonPathStreamingServiceTest extends ExampleServiceCase {
+
+  private static final String PATH_TO_ARRAY = "$.some_integers";
+  private static final String PATH_NOT_FOUND = "$.path.not.found";
+  private static final String JSON_PATH = "JsonPath";
+  private static final String JSON_RESULT_KEY = "JsonResultKey";
+  private static final String BASE_DIR_KEY = "JsonPathServiceExamples.baseDir";
+
+  private static final String STORE_BOOK_0_TITLE = "$.store.book[0].title";
+  private static final String SAYINGS_OF_THE_CENTURY = "Sayings of the Century";
+  private static final String SWORD_OF_HONOUR = "Sword of Honour";
+  private static final String STORE_BOOK_1_TITLE = "$.store.book[1].title";
+
+  private static final String JSON_WITH_NULL =
+      "{\r\n" + "    \"LastModifiedDate\": \"2017-11-23T15:15:31.000+0000\",\r\n" + "    \"WhatId\": null,\r\n"
+          + "    \"Description\": \"wanted more info on ebusiness and agility including analytical models\"\r\n" + "}";
+
+  private static Configuration jsonConfig = new Configuration.ConfigurationBuilder().jsonProvider(new JsonSmartJsonProvider())
+      .mappingProvider(new JacksonMappingProvider()).options(EnumSet.noneOf(Option.class)).build();
+
+  public JsonPathStreamingServiceTest() {
+    super();
+    if (PROPERTIES.getProperty(BASE_DIR_KEY) != null) {
+      setBaseDir(PROPERTIES.getProperty(BASE_DIR_KEY));
+    }
+  }
+
+  AdaptrisMessage createMessage() throws Exception {
+    return DefaultMessageFactory.getDefaultInstance().newMessage(sampleJsonContent());
+  }
+
+  @Test
+  public void testExtract_JsonObject() throws Exception {
+    MetadataDataOutputParameter targetMetadataDestination = new MetadataDataOutputParameter(JSON_RESULT_KEY);
+    ConstantDataInputParameter constantDataDestination = new ConstantDataInputParameter("$.store.bicycle");
+    AdaptrisMessage message = createMessage();
+    JsonPathExecution execution = new JsonPathExecution(constantDataDestination, targetMetadataDestination);
+
+    JsonPathStreamingService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ execution }));
+    jsonPathService.setSurfer(JsonPathStreamingService.Surfer.JACKSON);
+    execute(jsonPathService, message);
+
+    // Should be {"color":"red","price":19.95} so we can extract the color and price
+    String json = message.getMetadataValue(JSON_RESULT_KEY);
+
+    Collector collector = JsonSurferGson.INSTANCE.collector(json);
+    ValueBox<String> box1 = collector.collectOne("$.color", String.class);
+    ValueBox<Double> box2 = collector.collectOne("$.price", Double.class);
+    collector.exec();
+    String color = box1.get();
+    Double price = box2.get();
+
+    assertEquals("red", color);
+    assertEquals(19.95, price, 0.1);
+  }
+
+  @Test
+  public void testExtract_JsonArray() throws Exception {
+    MetadataDataOutputParameter targetMetadataDestination = new MetadataDataOutputParameter(JSON_RESULT_KEY);
+    ConstantDataInputParameter constantDataDestination = new ConstantDataInputParameter("$.store.book");
+    AdaptrisMessage message = createMessage();
+    JsonPathExecution execution = new JsonPathExecution(constantDataDestination, targetMetadataDestination);
+
+    JsonPathStreamingService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ execution }));
+    jsonPathService.setSurfer(JsonPathStreamingService.Surfer.GSON);
+    execute(jsonPathService, message);
+
+    // This gets us all the books, which is an array, so we can interrogate all this as well.
+    // [{book}, {book}, {book}]
+    String json = message.getMetadataValue(JSON_RESULT_KEY);
+
+    Collector collector = JsonSurferJsonSimple.INSTANCE.collector(json);
+    ValueBox<String> box1 = collector.collectOne("$[0].title", String.class);
+    ValueBox<String> box2 = collector.collectOne("$[1].title", String.class);
+    collector.exec();
+    String title0 = box1.get();
+    String title1 = box2.get();
+
+    assertEquals(SAYINGS_OF_THE_CENTURY, title0);
+    assertEquals(SWORD_OF_HONOUR, title1);
+  }
+
+  @Test
+  public void testSimpleResultFromPayloadToMetadata() throws Exception {
+    MetadataDataOutputParameter targetMetadataDestination = new MetadataDataOutputParameter(JSON_RESULT_KEY);
+    ConstantDataInputParameter constantDataDestination = new ConstantDataInputParameter(STORE_BOOK_1_TITLE);
+    JsonPathExecution execution = new JsonPathExecution(constantDataDestination, targetMetadataDestination);
+    AdaptrisMessage message = createMessage();
+
+    JsonPathStreamingService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ execution }));
+    jsonPathService.setSurfer(JsonPathStreamingService.Surfer.FAST);
+    execute(jsonPathService, message);
+
+    assertTrue(message.headersContainsKey(JSON_RESULT_KEY));
+    assertEquals(SWORD_OF_HONOUR, message.getMetadataValue(JSON_RESULT_KEY));
+  }
+
+  @Test
+  public void testPathNotFound_NoSuppress_Execution() throws Exception {
+    MetadataDataOutputParameter targetMetadataDestination = new MetadataDataOutputParameter(JSON_RESULT_KEY);
+    ConstantDataInputParameter constantDataDestination = new ConstantDataInputParameter(PATH_NOT_FOUND);
+    Execution execution = new Execution(constantDataDestination, targetMetadataDestination);
+
+    AdaptrisMessage message = createMessage();
+    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new Execution[]{ execution }));
+
+    try {
+      execute(jsonPathService, message);
+      fail();
+    } catch (ServiceException expected) {
+      // expected
+    }
+
+    assertFalse(message.headersContainsKey(JSON_RESULT_KEY));
+  }
+
+  @Test
+  public void testPathNotFound_Suppress() throws Exception {
+    MetadataDataOutputParameter targetMetadataDestination = new MetadataDataOutputParameter(JSON_RESULT_KEY);
+    ConstantDataInputParameter constantDataDestination = new ConstantDataInputParameter(PATH_NOT_FOUND);
+    JsonPathExecution execution = new JsonPathExecution(constantDataDestination, targetMetadataDestination).withSuppressPathNotFound(true);
+    AdaptrisMessage message = createMessage();
+
+    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(),
+            Arrays.asList(new JsonPathExecution[]
+                    {
+                            execution
+                    }));
+    execute(jsonPathService, message);
+
+    assertFalse(message.headersContainsKey(JSON_RESULT_KEY));
+  }
+
+  @Test
+  public void testPathNotFound_NoSuppress() throws Exception {
+    MetadataDataOutputParameter targetMetadataDestination = new MetadataDataOutputParameter(JSON_RESULT_KEY);
+    ConstantDataInputParameter constantDataDestination = new ConstantDataInputParameter(PATH_NOT_FOUND);
+    JsonPathExecution execution = new JsonPathExecution(constantDataDestination, targetMetadataDestination);
+    AdaptrisMessage message = createMessage();
+
+    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ execution }));
+
+    try {
+      execute(jsonPathService, message);
+      fail();
+    } catch (ServiceException expected) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testService_UnwrapJson() throws Exception {
+    MetadataDataOutputParameter targetMetadataDestination = new MetadataDataOutputParameter(JSON_RESULT_KEY);
+    ConstantDataInputParameter constantDataDestination = new ConstantDataInputParameter(PATH_TO_ARRAY);
+    JsonPathExecution execution = new JsonPathExecution(constantDataDestination, targetMetadataDestination);
+    AdaptrisMessage message = createMessage();
+
+    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ execution }));
+    jsonPathService.setUnwrapJson(true);
+    execute(jsonPathService, message);
+
+    assertTrue(message.headersContainsKey(JSON_RESULT_KEY));
+    assertEquals("1,2,3,4", message.getMetadataValue(JSON_RESULT_KEY));
+  }
+
+  @Test
+  public void testService_NoUnwrapJson() throws Exception {
+    MetadataDataOutputParameter targetMetadataDestination = new MetadataDataOutputParameter(JSON_RESULT_KEY);
+    ConstantDataInputParameter constantDataDestination = new ConstantDataInputParameter(PATH_TO_ARRAY);
+    JsonPathExecution execution = new JsonPathExecution(constantDataDestination, targetMetadataDestination);
+    AdaptrisMessage message = createMessage();
+
+    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ execution }));
+    execute(jsonPathService, message);
+
+    assertTrue(message.headersContainsKey(JSON_RESULT_KEY));
+    assertEquals("[1,2,3,4]", message.getMetadataValue(JSON_RESULT_KEY));
+  }
+
+  @Test
+  public void testNotJson() throws Exception {
+    MetadataDataOutputParameter targetMetadataDestination = new MetadataDataOutputParameter(JSON_RESULT_KEY);
+    ConstantDataInputParameter constantDataDestination = new ConstantDataInputParameter(PATH_NOT_FOUND);
+    JsonPathExecution execution = new JsonPathExecution(constantDataDestination, targetMetadataDestination);
+    AdaptrisMessage message = DefaultMessageFactory.getDefaultInstance().newMessage("");
+
+    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ execution }));
+
+    try {
+      execute(jsonPathService, message);
+      fail();
+    } catch (ServiceException expected) {
+      assertEquals(JsonSurfingException.class, expected.getCause().getClass());
+    }
+  }
+
+  @Test
+  public void testSimpleResultFromPayloadToMetadataUsingMetadataJsonPath() throws Exception {
+    AdaptrisMessage message = createMessage();
+    message.addMetadata(JSON_PATH, STORE_BOOK_1_TITLE);
+    MetadataDataOutputParameter targetMetadataDestination = new MetadataDataOutputParameter(JSON_RESULT_KEY);
+    MetadataDataInputParameter jsonMetadataDestination = new MetadataDataInputParameter(JSON_PATH);
+    jsonMetadataDestination.setMetadataKey(JSON_PATH);
+    JsonPathExecution execution = new JsonPathExecution(jsonMetadataDestination, targetMetadataDestination);
+
+    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ execution }));
+    execute(jsonPathService, message);
+
+    assertTrue(message.headersContainsKey(JSON_RESULT_KEY));
+    assertEquals(SWORD_OF_HONOUR, message.getMetadataValue(JSON_RESULT_KEY));
+  }
+
+  @Test
+  public void testSimpleResultFromMetadataToPayload() throws Exception {
+    MetadataStreamInputParameter sourceMetadataDestination = new MetadataStreamInputParameter(JSON_RESULT_KEY);
+    StringPayloadDataOutputParameter targetPayloadDestination = new StringPayloadDataOutputParameter();
+    ConstantDataInputParameter constantDataDestination = new ConstantDataInputParameter(STORE_BOOK_1_TITLE);
+    JsonPathExecution execution = new JsonPathExecution(constantDataDestination, targetPayloadDestination);
+    AdaptrisMessage message = DefaultMessageFactory.getDefaultInstance().newMessage();
+    message.addMetadata(JSON_RESULT_KEY, sampleJsonContent());
+
+    JsonPathService jsonPathService = new JsonPathStreamingService(sourceMetadataDestination, Arrays.asList(new JsonPathExecution[]{ execution }));
+    jsonPathService.setSource(sourceMetadataDestination);
+    jsonPathService.setExecutions(Arrays.asList(new JsonPathExecution[]{ execution }));
+    execute(jsonPathService, message);
+
+    assertEquals(SWORD_OF_HONOUR, message.getContent());
+  }
+
+  @Test
+  public void testSimpleResultFromMetadataToPayloadUsingMetadataJsonPath() throws Exception {
+    AdaptrisMessage message = DefaultMessageFactory.getDefaultInstance().newMessage();
+    message.addMetadata(JSON_PATH, STORE_BOOK_1_TITLE);
+    message.addMetadata(JSON_RESULT_KEY, sampleJsonContent());
+    MetadataStreamInputParameter sourceMetadataDestination = new MetadataStreamInputParameter(JSON_RESULT_KEY);
+    MetadataDataInputParameter sourceJsonPathDestination = new MetadataDataInputParameter(JSON_PATH);
+    JsonPathExecution execution = new JsonPathExecution(sourceJsonPathDestination, new StringPayloadDataOutputParameter());
+
+    JsonPathService jsonPathService = new JsonPathStreamingService(sourceMetadataDestination, Arrays.asList(new JsonPathExecution[]{ execution }));
+    jsonPathService.setExecutions(Arrays.asList(new JsonPathExecution[]{ execution }));
+    jsonPathService.setSource(sourceMetadataDestination);
+    execute(jsonPathService, message);
+
+    assertEquals(SWORD_OF_HONOUR, message.getContent());
+  }
+
+  @Test
+  public void testSimpleResultFromPayloadToMultipleDestinations() throws Exception {
+    MetadataDataOutputParameter targetMetadataDestination = new MetadataDataOutputParameter(JSON_RESULT_KEY);
+    ConstantDataInputParameter constantDataDestination = new ConstantDataInputParameter(STORE_BOOK_0_TITLE);
+    JsonPathExecution exec1 = new JsonPathExecution(constantDataDestination, targetMetadataDestination);
+    JsonPathExecution exec2 = new JsonPathExecution(constantDataDestination, new StringPayloadDataOutputParameter());
+    AdaptrisMessage message = createMessage();
+
+    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ exec1, exec2 }));
+    execute(jsonPathService, message);
+
+    assertEquals(SAYINGS_OF_THE_CENTURY, message.getContent());
+    assertEquals(SAYINGS_OF_THE_CENTURY, message.getMetadataValue(JSON_RESULT_KEY));
+  }
+
+  @Test
+  public void testSimpleResultFromPayloadToMultiplePayloadDestinations() throws Exception {
+    ConstantDataInputParameter constantDataDestination1 = new ConstantDataInputParameter(STORE_BOOK_0_TITLE);
+    ConstantDataInputParameter constantDataDestination2 = new ConstantDataInputParameter(STORE_BOOK_1_TITLE);
+    JsonPathExecution exec1 = new JsonPathExecution(constantDataDestination1, new StringPayloadDataOutputParameter());
+    JsonPathExecution exec2 = new JsonPathExecution(constantDataDestination2, new StringPayloadDataOutputParameter());
+    AdaptrisMessage message = createMessage();
+
+    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ exec1, exec2 }));
+    execute(jsonPathService, message);
+
+    assertEquals(SWORD_OF_HONOUR, message.getContent());
+  }
+
+  @Test
+  public void testComplexResultFromPayloadToPayload() throws Exception {
+    ConstantDataInputParameter constantDataDestination = new ConstantDataInputParameter("$..book[?(@.isbn)]");
+    JsonPathExecution execution = new JsonPathExecution(constantDataDestination, new StringPayloadDataOutputParameter());
+    AdaptrisMessage message = createMessage();
+
+    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ execution }));
+    execute(jsonPathService, message);
+
+    Collector collector = JsonSurferFastJson.INSTANCE.collector(message.getInputStream());
+    ValueBox<String> box1 = collector.collectOne("$[0].author", String.class);
+    ValueBox<String> box2 = collector.collectOne("$[1].author", String.class);
+    collector.exec();
+    assertEquals("Herman Melville", box1.get());
+    assertEquals("J. R. R. Tolkien", box2.get());
+  }
+
+  @Test
+  public void testNullToEmptyString_JsonExecution() throws Exception {
+    MetadataDataOutputParameter targetMetadataDestination = new MetadataDataOutputParameter(JSON_RESULT_KEY);
+    ConstantDataInputParameter constantDataDestination = new ConstantDataInputParameter("$.WhatId");
+    JsonPathExecution execution = new JsonPathExecution(constantDataDestination, targetMetadataDestination).withNullConverter(new NullToEmptyStringConverter());
+    AdaptrisMessage message = DefaultMessageFactory.getDefaultInstance().newMessage(JSON_WITH_NULL);
+
+    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), execution);
+    execute(jsonPathService, message);
+
+    assertEquals("", message.getMetadataValue(JSON_RESULT_KEY));
+  }
+
+  @Test
+  public void testNullToEmptyString_JsonExecution_DefaultBehaviour() throws Exception {
+    MetadataDataOutputParameter targetMetadataDestination = new MetadataDataOutputParameter(JSON_RESULT_KEY);
+    ConstantDataInputParameter constantDataDestination = new ConstantDataInputParameter("$.WhatId");
+    JsonPathExecution execution = new JsonPathExecution(constantDataDestination, targetMetadataDestination);
+    AdaptrisMessage message = DefaultMessageFactory.getDefaultInstance().newMessage(JSON_WITH_NULL);
+
+    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), execution);
+    execute(jsonPathService, message);
+
+    assertEquals("null", message.getMetadataValue(JSON_RESULT_KEY));
+  }
+
+  @Test
+  public void testNullToEmptyString_Execution() throws Exception {
+    MetadataDataOutputParameter targetMetadataDestination = new MetadataDataOutputParameter(JSON_RESULT_KEY);
+    ConstantDataInputParameter constantDataDestination = new ConstantDataInputParameter("$.WhatId");
+    Execution execution = new Execution(constantDataDestination, targetMetadataDestination);
+    AdaptrisMessage message = DefaultMessageFactory.getDefaultInstance().newMessage(JSON_WITH_NULL);
+
+    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), execution);
+
+    try {
+      execute(jsonPathService, message);
+      fail();
+    } catch (ServiceException expected) {
+      // expected
+    }
+  }
+
+  @Override
+  protected Object retrieveObjectForSampleConfig() {
+    JsonPathStreamingService jsonPathService = null;
+    ConstantDataInputParameter constantDataDestination1 = new ConstantDataInputParameter(STORE_BOOK_0_TITLE);
+    ConstantDataInputParameter constantDataDestination2 = new ConstantDataInputParameter(STORE_BOOK_1_TITLE);
+    JsonPathExecution exec1 = new JsonPathExecution(constantDataDestination1, new MetadataDataOutputParameter("targetMetadataKey1"));
+    JsonPathExecution exec2 = new JsonPathExecution(constantDataDestination2, new MetadataDataOutputParameter("targetMetadataKey2"));
+
+    jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), new ArrayList<>(Arrays.asList(new JsonPathExecution[]{ exec1, exec2 })));
+    jsonPathService.setSurfer(JsonPathStreamingService.Surfer.SIMPLE);
+    return jsonPathService;
+  }
+
+  public static String sampleJsonContent() {
+    return "{"
+    + "\"store\": {"
+    +    "\"book\": ["
+    +        "{"
+    +            "\"category\": \"reference\","
+    +            "\"author\": \"Nigel Rees\","
+    +            "\"title\": \"Sayings of the Century\","
+    +            "\"price\": 8.95"
+    +        "},"
+    +        "{"
+    +            "\"category\": \"fiction\","
+    +            "\"author\": \"Evelyn Waugh\","
+    +            "\"title\": \"Sword of Honour\","
+    +            "\"price\": 12.99"
+    +        "},"
+    +        "{"
+    +            "\"category\": \"fiction\","
+    +            "\"author\": \"Herman Melville\","
+    +            "\"title\": \"Moby Dick\","
+    +            "\"isbn\": \"0-553-21311-3\","
+    +            "\"price\": 8.99"
+    +        "},"
+    +        "{"
+    +            "\"category\": \"fiction\","
+    +            "\"author\": \"J. R. R. Tolkien\","
+    +            "\"title\": \"The Lord of the Rings\","
+    +            "\"isbn\": \"0-395-19395-8\","
+    +            "\"price\": 22.99"
+    +        "}"
+    +    "],"
+    +    "\"bicycle\": {"
+    +        "\"color\": \"red\","
+    +        "\"price\": 19.95"
+    +    "}"
+    + "},"
+    + "\"expensive\": 10,"
+    + "\"some_integers\" : [1,2,3,4]"
+    + "}";
+  }
+
+  private String complexExpected() {
+    return "["
+        + "{\"author\":\"Herman Melville\",\"price\":8.99,\"isbn\":\"0-553-21311-3\",\"category\":\"fiction\",\"title\":\"Moby Dick\"},"
+        + "{\"author\":\"J. R. R. Tolkien\",\"price\":22.99,\"isbn\":\"0-395-19395-8\",\"category\":\"fiction\",\"title\":\"The Lord of the Rings\"}"
+        + "]";
+  }
+}

--- a/interlok-json-streaming/src/test/java/com/adaptris/core/json/streaming/JsonPathStreamingServiceTest.java
+++ b/interlok-json-streaming/src/test/java/com/adaptris/core/json/streaming/JsonPathStreamingServiceTest.java
@@ -11,7 +11,6 @@ import com.adaptris.core.common.MetadataStreamInputParameter;
 import com.adaptris.core.common.PayloadStreamInputParameter;
 import com.adaptris.core.common.StringPayloadDataOutputParameter;
 import com.adaptris.core.json.JsonPathExecution;
-import com.adaptris.core.services.path.json.JsonPathService;
 import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 import com.adaptris.util.text.NullToEmptyStringConverter;
 import com.jayway.jsonpath.Configuration;
@@ -139,7 +138,7 @@ public class JsonPathStreamingServiceTest extends ExampleServiceCase {
     Execution execution = new Execution(constantDataDestination, targetMetadataDestination);
 
     AdaptrisMessage message = createMessage();
-    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new Execution[]{ execution }));
+    JsonPathStreamingService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new Execution[]{ execution }));
 
     try {
       execute(jsonPathService, message);
@@ -158,7 +157,7 @@ public class JsonPathStreamingServiceTest extends ExampleServiceCase {
     JsonPathExecution execution = new JsonPathExecution(constantDataDestination, targetMetadataDestination).withSuppressPathNotFound(true);
     AdaptrisMessage message = createMessage();
 
-    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(),
+    JsonPathStreamingService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(),
             Arrays.asList(new JsonPathExecution[]
                     {
                             execution
@@ -175,7 +174,7 @@ public class JsonPathStreamingServiceTest extends ExampleServiceCase {
     JsonPathExecution execution = new JsonPathExecution(constantDataDestination, targetMetadataDestination);
     AdaptrisMessage message = createMessage();
 
-    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ execution }));
+    JsonPathStreamingService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ execution }));
 
     try {
       execute(jsonPathService, message);
@@ -192,7 +191,7 @@ public class JsonPathStreamingServiceTest extends ExampleServiceCase {
     JsonPathExecution execution = new JsonPathExecution(constantDataDestination, targetMetadataDestination);
     AdaptrisMessage message = createMessage();
 
-    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ execution }));
+    JsonPathStreamingService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ execution }));
     jsonPathService.setUnwrapJson(true);
     execute(jsonPathService, message);
 
@@ -207,7 +206,7 @@ public class JsonPathStreamingServiceTest extends ExampleServiceCase {
     JsonPathExecution execution = new JsonPathExecution(constantDataDestination, targetMetadataDestination);
     AdaptrisMessage message = createMessage();
 
-    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ execution }));
+    JsonPathStreamingService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ execution }));
     execute(jsonPathService, message);
 
     assertTrue(message.headersContainsKey(JSON_RESULT_KEY));
@@ -221,7 +220,7 @@ public class JsonPathStreamingServiceTest extends ExampleServiceCase {
     JsonPathExecution execution = new JsonPathExecution(constantDataDestination, targetMetadataDestination);
     AdaptrisMessage message = DefaultMessageFactory.getDefaultInstance().newMessage("");
 
-    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ execution }));
+    JsonPathStreamingService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ execution }));
 
     try {
       execute(jsonPathService, message);
@@ -240,7 +239,7 @@ public class JsonPathStreamingServiceTest extends ExampleServiceCase {
     jsonMetadataDestination.setMetadataKey(JSON_PATH);
     JsonPathExecution execution = new JsonPathExecution(jsonMetadataDestination, targetMetadataDestination);
 
-    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ execution }));
+    JsonPathStreamingService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ execution }));
     execute(jsonPathService, message);
 
     assertTrue(message.headersContainsKey(JSON_RESULT_KEY));
@@ -256,7 +255,7 @@ public class JsonPathStreamingServiceTest extends ExampleServiceCase {
     AdaptrisMessage message = DefaultMessageFactory.getDefaultInstance().newMessage();
     message.addMetadata(JSON_RESULT_KEY, sampleJsonContent());
 
-    JsonPathService jsonPathService = new JsonPathStreamingService(sourceMetadataDestination, Arrays.asList(new JsonPathExecution[]{ execution }));
+    JsonPathStreamingService jsonPathService = new JsonPathStreamingService(sourceMetadataDestination, Arrays.asList(new JsonPathExecution[]{ execution }));
     jsonPathService.setSource(sourceMetadataDestination);
     jsonPathService.setExecutions(Arrays.asList(new JsonPathExecution[]{ execution }));
     execute(jsonPathService, message);
@@ -273,7 +272,7 @@ public class JsonPathStreamingServiceTest extends ExampleServiceCase {
     MetadataDataInputParameter sourceJsonPathDestination = new MetadataDataInputParameter(JSON_PATH);
     JsonPathExecution execution = new JsonPathExecution(sourceJsonPathDestination, new StringPayloadDataOutputParameter());
 
-    JsonPathService jsonPathService = new JsonPathStreamingService(sourceMetadataDestination, Arrays.asList(new JsonPathExecution[]{ execution }));
+    JsonPathStreamingService jsonPathService = new JsonPathStreamingService(sourceMetadataDestination, Arrays.asList(new JsonPathExecution[]{ execution }));
     jsonPathService.setExecutions(Arrays.asList(new JsonPathExecution[]{ execution }));
     jsonPathService.setSource(sourceMetadataDestination);
     execute(jsonPathService, message);
@@ -289,7 +288,7 @@ public class JsonPathStreamingServiceTest extends ExampleServiceCase {
     JsonPathExecution exec2 = new JsonPathExecution(constantDataDestination, new StringPayloadDataOutputParameter());
     AdaptrisMessage message = createMessage();
 
-    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ exec1, exec2 }));
+    JsonPathStreamingService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ exec1, exec2 }));
     execute(jsonPathService, message);
 
     assertEquals(SAYINGS_OF_THE_CENTURY, message.getContent());
@@ -304,7 +303,7 @@ public class JsonPathStreamingServiceTest extends ExampleServiceCase {
     JsonPathExecution exec2 = new JsonPathExecution(constantDataDestination2, new StringPayloadDataOutputParameter());
     AdaptrisMessage message = createMessage();
 
-    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ exec1, exec2 }));
+    JsonPathStreamingService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ exec1, exec2 }));
     execute(jsonPathService, message);
 
     assertEquals(SWORD_OF_HONOUR, message.getContent());
@@ -316,7 +315,7 @@ public class JsonPathStreamingServiceTest extends ExampleServiceCase {
     JsonPathExecution execution = new JsonPathExecution(constantDataDestination, new StringPayloadDataOutputParameter());
     AdaptrisMessage message = createMessage();
 
-    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ execution }));
+    JsonPathStreamingService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ execution }));
     execute(jsonPathService, message);
 
     Collector collector = JsonSurferFastJson.INSTANCE.collector(message.getInputStream());
@@ -334,7 +333,7 @@ public class JsonPathStreamingServiceTest extends ExampleServiceCase {
     JsonPathExecution execution = new JsonPathExecution(constantDataDestination, targetMetadataDestination).withNullConverter(new NullToEmptyStringConverter());
     AdaptrisMessage message = DefaultMessageFactory.getDefaultInstance().newMessage(JSON_WITH_NULL);
 
-    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), execution);
+    JsonPathStreamingService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), execution);
     execute(jsonPathService, message);
 
     assertEquals("", message.getMetadataValue(JSON_RESULT_KEY));
@@ -347,7 +346,7 @@ public class JsonPathStreamingServiceTest extends ExampleServiceCase {
     JsonPathExecution execution = new JsonPathExecution(constantDataDestination, targetMetadataDestination);
     AdaptrisMessage message = DefaultMessageFactory.getDefaultInstance().newMessage(JSON_WITH_NULL);
 
-    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), execution);
+    JsonPathStreamingService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), execution);
     execute(jsonPathService, message);
 
     assertEquals("null", message.getMetadataValue(JSON_RESULT_KEY));
@@ -360,7 +359,7 @@ public class JsonPathStreamingServiceTest extends ExampleServiceCase {
     Execution execution = new Execution(constantDataDestination, targetMetadataDestination);
     AdaptrisMessage message = DefaultMessageFactory.getDefaultInstance().newMessage(JSON_WITH_NULL);
 
-    JsonPathService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), execution);
+    JsonPathStreamingService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), execution);
 
     try {
       execute(jsonPathService, message);

--- a/interlok-json/src/main/java/com/adaptris/core/services/path/json/JsonPathService.java
+++ b/interlok-json/src/main/java/com/adaptris/core/services/path/json/JsonPathService.java
@@ -1,29 +1,17 @@
 package com.adaptris.core.services.path.json;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Map;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-import org.apache.commons.lang3.BooleanUtils;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
-import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.ServiceImp;
 import com.adaptris.core.common.Execution;
 import com.adaptris.core.common.StringPayloadDataInputParameter;
-import com.adaptris.core.json.JsonPathExecution;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.interlok.config.DataInputParameter;
 import com.adaptris.interlok.config.DataOutputParameter;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
@@ -32,11 +20,16 @@ import com.jayway.jsonpath.ReadContext;
 import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-import com.thoughtworks.xstream.annotations.XStreamImplicit;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
 
 /**
  * This service allows you to search JSON content and the results are then set back into the message.
@@ -146,7 +139,7 @@ import lombok.Setter;
 @ComponentProfile(summary = "Extract a value from a JSON document", tag = "service,transform,json,metadata")
 @DisplayOrder(order = {"source", "executions", "unwrapJson"})
 @NoArgsConstructor
-public class JsonPathService extends ServiceImp {
+public class JsonPathService extends JsonPathServiceImpl {
 
   /**
    * The source for executing the jsonpath against.
@@ -157,34 +150,9 @@ public class JsonPathService extends ServiceImp {
   @Getter
   @Setter
   @NonNull
-  protected DataInputParameter source = new StringPayloadDataInputParameter();
+  private DataInputParameter<String> source = new StringPayloadDataInputParameter();
 
-  /**
-   * The list of jsonpath executions to apply.
-   *
-   */
-  @NotNull
-  @Valid
-  @AutoPopulated
-  @XStreamImplicit
-  @Getter
-  @Setter
-  @NonNull
-  protected List<Execution> executions = new ArrayList<>();
-
-  protected transient Configuration jsonConfig;
-
-  /**
-   * Get whether the JSON should be unwrapped removing any leading or trailing square brackets
-   * {@code []}.
-   * <p>
-   * The default is false if not specified.
-   * </p>
-   */
-  @Getter
-  @Setter
-  @InputFieldDefault(value = "false")
-  protected Boolean unwrapJson;
+  private transient Configuration jsonConfig;
 
   public JsonPathService(DataInputParameter<String> source, Execution... executions) {
     this(source, new ArrayList<>(Arrays.asList(executions)));
@@ -203,8 +171,7 @@ public class JsonPathService extends ServiceImp {
   public void doService(final AdaptrisMessage message) throws ServiceException {
     try {
 
-      final DataInputParameter<String> src = source;
-      final String rawJson = src.extract(message);
+      final String rawJson = source.extract(message);
       ReadContext context = JsonPath.parse(rawJson, jsonConfig);
 
       for (final Execution execution : executions) {
@@ -231,67 +198,9 @@ public class JsonPathService extends ServiceImp {
     }
   }
 
-  protected static String toString(Object json, Execution exec) throws Exception {
-    ObjectMapper mapper = new ObjectMapper();
-    Object jsonObject = convertIfNull(json, exec);
-    // A JSON Object is effectively a map, so we need to write that out as JSON.
-    // If it's a JSONArray, then "toString" works fine.
-    if (Map.class.isAssignableFrom(jsonObject.getClass())) {
-      return mapper.writeValueAsString(jsonObject);
-    }
-    if (List.class.isAssignableFrom(jsonObject.getClass())) {
-      return mapper.writeValueAsString(jsonObject);
-    }
-    return jsonObject.toString();
-  }
-
-  /**
-   * Strip (if necessary) the leading/trailing [] from the JSON.
-   *
-   * @param json
-   *        The JSON string.
-   */
-  protected static String unwrap(final String json, boolean unwrapJson) {
-    if (unwrapJson) {
-      if (json.startsWith("[") && json.endsWith("]")) {
-        return json.substring(1, json.length() - 1);
-      }
-    }
-    return json;
-  }
-
   @Override
   public void prepare() throws CoreException {
     jsonConfig = new Configuration.ConfigurationBuilder().jsonProvider(new JsonSmartJsonProvider())
         .mappingProvider(new JacksonMappingProvider()).options(EnumSet.noneOf(Option.class)).build();
   }
-
-  @Override
-  protected void closeService() {
-    /* unused/empty method */
-  }
-
-  @Override
-  protected void initService() throws CoreException {
-    // nothing to do.
-  }
-
-  protected boolean unwrapJson() {
-    return BooleanUtils.toBooleanDefaultIfNull(getUnwrapJson(), false);
-  }
-
-  protected boolean suppressPathNotFound(Execution exec) {
-    if (exec instanceof JsonPathExecution) {
-      return ((JsonPathExecution) exec).suppressPathNotFound();
-    }
-    return false;
-  }
-
-  protected static Object convertIfNull(Object o, Execution exec) {
-    if (exec instanceof JsonPathExecution) {
-      return ((JsonPathExecution) exec).nullConverter().convert(o);
-    }
-    return o;
-  }
-
 }

--- a/interlok-json/src/main/java/com/adaptris/core/services/path/json/JsonPathService.java
+++ b/interlok-json/src/main/java/com/adaptris/core/services/path/json/JsonPathService.java
@@ -157,7 +157,7 @@ public class JsonPathService extends ServiceImp {
   @Getter
   @Setter
   @NonNull
-  private DataInputParameter<String> source = new StringPayloadDataInputParameter();
+  protected DataInputParameter source = new StringPayloadDataInputParameter();
 
   /**
    * The list of jsonpath executions to apply.
@@ -170,7 +170,7 @@ public class JsonPathService extends ServiceImp {
   @Getter
   @Setter
   @NonNull
-  private List<Execution> executions = new ArrayList<>();
+  protected List<Execution> executions = new ArrayList<>();
 
   protected transient Configuration jsonConfig;
 
@@ -184,8 +184,7 @@ public class JsonPathService extends ServiceImp {
   @Getter
   @Setter
   @InputFieldDefault(value = "false")
-  private Boolean unwrapJson;
-
+  protected Boolean unwrapJson;
 
   public JsonPathService(DataInputParameter<String> source, Execution... executions) {
     this(source, new ArrayList<>(Arrays.asList(executions)));
@@ -240,6 +239,9 @@ public class JsonPathService extends ServiceImp {
     if (Map.class.isAssignableFrom(jsonObject.getClass())) {
       return mapper.writeValueAsString(jsonObject);
     }
+    if (List.class.isAssignableFrom(jsonObject.getClass())) {
+      return mapper.writeValueAsString(jsonObject);
+    }
     return jsonObject.toString();
   }
 
@@ -285,7 +287,7 @@ public class JsonPathService extends ServiceImp {
     return false;
   }
 
-  private static Object convertIfNull(Object o, Execution exec) {
+  protected static Object convertIfNull(Object o, Execution exec) {
     if (exec instanceof JsonPathExecution) {
       return ((JsonPathExecution) exec).nullConverter().convert(o);
     }

--- a/interlok-json/src/main/java/com/adaptris/core/services/path/json/JsonPathServiceImpl.java
+++ b/interlok-json/src/main/java/com/adaptris/core/services/path/json/JsonPathServiceImpl.java
@@ -1,0 +1,122 @@
+package com.adaptris.core.services.path.json;
+
+import com.adaptris.annotation.AutoPopulated;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceImp;
+import com.adaptris.core.common.Execution;
+import com.adaptris.core.common.StringPayloadDataInputParameter;
+import com.adaptris.core.json.JsonPathExecution;
+import com.adaptris.interlok.config.DataInputParameter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+import org.apache.commons.lang3.BooleanUtils;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This is the base for JSON path services, which allows you to search
+ * JSON content with the results then being set back into the message.
+ * <p>
+ * The searching works in much the same way as XPath, for more
+ * information on how to build a JSON path see the
+ * <a href="https://github.com/jayway/JsonPath">JSONPath</a>
+ * documentation.
+ * </p>
+ * See individual implementations for further documentation.
+ */
+@NoArgsConstructor
+public abstract class JsonPathServiceImpl extends ServiceImp {
+
+  /**
+   * The list of jsonpath executions to apply.
+   *
+   */
+  @NotNull
+  @Valid
+  @AutoPopulated
+  @XStreamImplicit
+  @Getter
+  @Setter
+  @NonNull
+  protected List<Execution> executions = new ArrayList<>();
+
+  /**
+   * Get whether the JSON should be unwrapped removing any leading or trailing square brackets
+   * {@code []}.
+   * <p>
+   * The default is false if not specified.
+   * </p>
+   */
+  @Getter
+  @Setter
+  @InputFieldDefault(value = "false")
+  protected Boolean unwrapJson;
+
+  protected static String toString(Object json, Execution exec) throws Exception {
+    ObjectMapper mapper = new ObjectMapper();
+    Object jsonObject = convertIfNull(json, exec);
+    // A JSON Object is effectively a map, so we need to write that out as JSON.
+    // If it's a JSONArray, then "toString" works fine.
+    if (Map.class.isAssignableFrom(jsonObject.getClass())) {
+      return mapper.writeValueAsString(jsonObject);
+    }
+    if (List.class.isAssignableFrom(jsonObject.getClass())) {
+      return mapper.writeValueAsString(jsonObject);
+    }
+    return jsonObject.toString();
+  }
+
+  /**
+   * Strip (if necessary) the leading/trailing [] from the JSON.
+   *
+   * @param json
+   *        The JSON string.
+   */
+  protected static String unwrap(final String json, boolean unwrapJson) {
+    if (unwrapJson) {
+      if (json.startsWith("[") && json.endsWith("]")) {
+        return json.substring(1, json.length() - 1);
+      }
+    }
+    return json;
+  }
+
+  @Override
+  protected void closeService() {
+    /* unused/empty method */
+  }
+
+  @Override
+  protected void initService() throws CoreException {
+    // nothing to do.
+  }
+
+  protected boolean unwrapJson() {
+    return BooleanUtils.toBooleanDefaultIfNull(getUnwrapJson(), false);
+  }
+
+  protected boolean suppressPathNotFound(Execution exec) {
+    if (exec instanceof JsonPathExecution) {
+      return ((JsonPathExecution) exec).suppressPathNotFound();
+    }
+    return false;
+  }
+
+  protected static Object convertIfNull(Object o, Execution exec) {
+    if (exec instanceof JsonPathExecution) {
+      return ((JsonPathExecution) exec).nullConverter().convert(o);
+    }
+    return o;
+  }
+
+}

--- a/interlok-json/src/main/java/com/adaptris/core/services/path/json/JsonPathServiceImpl.java
+++ b/interlok-json/src/main/java/com/adaptris/core/services/path/json/JsonPathServiceImpl.java
@@ -5,9 +5,7 @@ import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceImp;
 import com.adaptris.core.common.Execution;
-import com.adaptris.core.common.StringPayloadDataInputParameter;
 import com.adaptris.core.json.JsonPathExecution;
-import com.adaptris.interlok.config.DataInputParameter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 import lombok.Getter;
@@ -19,7 +17,6 @@ import org.apache.commons.lang3.BooleanUtils;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 

--- a/interlok-json/src/test/java/com/adaptris/core/services/path/json/JsonPathServiceTest.java
+++ b/interlok-json/src/test/java/com/adaptris/core/services/path/json/JsonPathServiceTest.java
@@ -1,13 +1,5 @@
 package com.adaptris.core.services.path.json;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.EnumSet;
-import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.DefaultMessageFactory;
 import com.adaptris.core.ServiceException;
@@ -26,6 +18,16 @@ import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.ReadContext;
 import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class JsonPathServiceTest extends ExampleServiceCase {
 


### PR DESCRIPTION
## Motivation

An alternative to Jayway JSON Path, that doesn't require parsing the entire JSON document, ideally works on streams.

## Modification

Add JSON path service that uses JSON Surfer to parse JSON as a stream and extract data using JSON path syntax. Unit tests cloned from original JSON path service.

## Result

The end user should now be able to query unfathomably large JSON documents with JSON path syntax and get results.

## Testing

The unit tests are cloned from the original JSON path service tests, just with references to the new service. There is also a [config](https://github.com/adaptris/interlok-json/files/6432500/adapter.xml.txt) that, at the very least, demonstrates that the new streaming JSON path service can extract data just as well as the original.