### PR TITLE
INTERLOK-3782 Remove fastjson dependency

### DIFF
--- a/interlok-json-streaming/build.gradle
+++ b/interlok-json-streaming/build.gradle
@@ -18,14 +18,14 @@ dependencies {
     exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
     exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
   }
-  compile("com.github.jsurfer:jsurfer-fastjson:$jsonSurferVersion") {
-    exclude group: "com.alibaba", module: "fastjson"
-  }
+  // compile("com.github.jsurfer:jsurfer-fastjson:$jsonSurferVersion") {
+  //   exclude group: "com.alibaba", module: "fastjson"
+  // }
   compile ("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
   compile ("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
   compile ("com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion")
 
-  compile("com.alibaba:fastjson:1.2.76")
+  // compile("com.alibaba:fastjson:1.2.76")
   compile("com.github.jsurfer:jsurfer-jsonsimple:$jsonSurferVersion")
 
   testCompile("org.skyscreamer:jsonassert:1.5.0")

--- a/interlok-json-streaming/src/main/java/com/adaptris/core/json/streaming/JsonPathStreamingService.java
+++ b/interlok-json-streaming/src/main/java/com/adaptris/core/json/streaming/JsonPathStreamingService.java
@@ -1,5 +1,21 @@
 package com.adaptris.core.json.streaming;
 
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.json.JsonException;
+import javax.validation.constraints.NotNull;
+import org.apache.commons.lang3.ObjectUtils;
+import org.jsfr.json.Collector;
+import org.jsfr.json.JsonSurfer;
+import org.jsfr.json.JsonSurferGson;
+import org.jsfr.json.JsonSurferJackson;
+import org.jsfr.json.JsonSurferJsonSimple;
+import org.jsfr.json.ValueBox;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
@@ -17,24 +33,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
-import org.apache.commons.lang3.ObjectUtils;
-import org.jsfr.json.Collector;
-import org.jsfr.json.JsonSurfer;
-import org.jsfr.json.JsonSurferFastJson;
-import org.jsfr.json.JsonSurferGson;
-import org.jsfr.json.JsonSurferJackson;
-import org.jsfr.json.JsonSurferJsonSimple;
-import org.jsfr.json.ValueBox;
-
-import javax.json.JsonException;
-import javax.validation.constraints.NotNull;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * This service allows you to search JSON content and the results are
@@ -255,12 +253,13 @@ public class JsonPathStreamingService extends JsonPathServiceImpl
       JsonSurfer getInstance() {
         return JsonSurferJsonSimple.INSTANCE;
       }
-    },
-    FAST {
-      @Override
-      JsonSurfer getInstance() {
-        return JsonSurferFastJson.INSTANCE;
-      }
+      // fastjson has a jersey service provider.
+      // },
+      // FAST {
+      // @Override
+      // JsonSurfer getInstance() {
+      // return JsonSurferFastJson.INSTANCE;
+      // }
     };
     abstract JsonSurfer getInstance();
   }

--- a/interlok-json-streaming/src/test/java/com/adaptris/core/json/streaming/JsonPathStreamingServiceTest.java
+++ b/interlok-json-streaming/src/test/java/com/adaptris/core/json/streaming/JsonPathStreamingServiceTest.java
@@ -1,5 +1,19 @@
 package com.adaptris.core.json.streaming;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import org.jsfr.json.Collector;
+import org.jsfr.json.JsonSurferGson;
+import org.jsfr.json.JsonSurferJackson;
+import org.jsfr.json.JsonSurferJsonSimple;
+import org.jsfr.json.ValueBox;
+import org.jsfr.json.exception.JsonSurfingException;
+import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.DefaultMessageFactory;
 import com.adaptris.core.ServiceException;
@@ -17,22 +31,6 @@ import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
-import org.jsfr.json.Collector;
-import org.jsfr.json.JsonSurferFastJson;
-import org.jsfr.json.JsonSurferGson;
-import org.jsfr.json.JsonSurferJsonSimple;
-import org.jsfr.json.ValueBox;
-import org.jsfr.json.exception.JsonSurfingException;
-import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.EnumSet;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class JsonPathStreamingServiceTest extends ExampleServiceCase {
 
@@ -124,7 +122,7 @@ public class JsonPathStreamingServiceTest extends ExampleServiceCase {
     AdaptrisMessage message = createMessage();
 
     JsonPathStreamingService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ execution }));
-    jsonPathService.setSurfer(JsonPathStreamingService.Surfer.FAST);
+    jsonPathService.setSurfer(JsonPathStreamingService.Surfer.JACKSON);
     execute(jsonPathService, message);
 
     assertTrue(message.headersContainsKey(JSON_RESULT_KEY));
@@ -318,7 +316,7 @@ public class JsonPathStreamingServiceTest extends ExampleServiceCase {
     JsonPathStreamingService jsonPathService = new JsonPathStreamingService(new PayloadStreamInputParameter(), Arrays.asList(new JsonPathExecution[]{ execution }));
     execute(jsonPathService, message);
 
-    Collector collector = JsonSurferFastJson.INSTANCE.collector(message.getInputStream());
+    Collector collector = JsonSurferJackson.INSTANCE.collector(message.getInputStream());
     ValueBox<String> box1 = collector.collectOne("$[0].author", String.class);
     ValueBox<String> box2 = collector.collectOne("$[1].author", String.class);
     collector.exec();


### PR DESCRIPTION
## Motivation

Since fastjson exposes a jersey service provider this interferes with the UI because of classloader issues.
There are alternatives to fastjson (gson/jackson/simple) so we can remove it since we don't have a hard dependency on it to assist with streaming json path

This was caused by : https://github.com/adaptris/interlok-json/pull/201

## Modification

Remove `FAST` from the Surfer enum
Modify tests so that they don't refer to it (using JACKSON instead).

## Result

The UI now starts if you have a dependency on interlok-json-streaming

## Testing

Using the normal develop snapshot. UI doesn't start.
Build using this version, delete fastjson.jar (since it will no longer be part of the dependencies). The UI now starts.

