### PR TITLE
INTERLOK-3815 Start using version 1.0.0-preview of JQ

### DIFF
--- a/interlok-jq/build.gradle
+++ b/interlok-jq/build.gradle
@@ -8,7 +8,9 @@ ext {
 
 dependencies {
   api ("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
-  api ("net.thisptr:jackson-jq:0.0.13")
+//  api ("net.thisptr:jackson-jq:0.0.13")
+  api ("net.thisptr:jackson-jq:1.0.0-preview.20210610")
+  api ("net.thisptr:jackson-jq-extra:1.0.0-preview.20210610")
   testImplementation ("com.jayway.jsonpath:json-path:2.6.0")
 }
 

--- a/interlok-jq/src/main/java/com/adaptris/core/json/jq/JsonJqTransform.java
+++ b/interlok-jq/src/main/java/com/adaptris/core/json/jq/JsonJqTransform.java
@@ -17,10 +17,13 @@ package com.adaptris.core.json.jq;
 
 import static com.adaptris.core.MetadataCollection.asMap;
 
+import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.ServiceLoader;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -43,8 +46,15 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
+import net.thisptr.jackson.jq.BuiltinFunctionLoader;
+import net.thisptr.jackson.jq.Function;
 import net.thisptr.jackson.jq.JsonQuery;
+import net.thisptr.jackson.jq.Output;
 import net.thisptr.jackson.jq.Scope;
+import net.thisptr.jackson.jq.Version;
+import net.thisptr.jackson.jq.exception.JsonQueryException;
+import net.thisptr.jackson.jq.internal.BuiltinFunction;
+import net.thisptr.jackson.jq.internal.JsonQueryFunction;
 
 /**
  * Transform a JSON document using JQ style syntax.
@@ -81,9 +91,12 @@ public class JsonJqTransform extends ServiceImp {
     try (Reader reader = msg.getReader();
         Writer w = msg.getWriter();
         JsonGenerator generator = mapper.getFactory().createGenerator(w).useDefaultPrettyPrinter()) {
-      JsonQuery q = JsonQuery.compile(querySource.extract(msg));
+      JsonQuery q = JsonQuery.compile(querySource.extract(msg), Version.LATEST);
       JsonNode jsonNode = mapper.readTree(reader);
-      List<JsonNode> result = q.apply(createScope(mapper, msg), jsonNode);
+
+      final List<JsonNode> result = new ArrayList<>();
+      q.apply(createScope(mapper, msg), jsonNode, out -> result.add(out));
+
       if (result.size() == 1) {
         generator.writeObject(result.get(0));
       }
@@ -161,8 +174,16 @@ public class JsonJqTransform extends ServiceImp {
 
   private Scope createScope(ObjectMapper mapper, AdaptrisMessage msg) {
     Map<String, String> filtered = asMap(metadataFilter().filter(msg));
-    Scope scope = new Scope(null);
-    scope.loadFunctions(Thread.currentThread().getContextClassLoader());
+    Scope scope = Scope.newEmptyScope();
+
+    //scope.loadFunctions(Thread.currentThread().getContextClassLoader());
+    BuiltinFunctionLoader functionLoader = BuiltinFunctionLoader.getInstance();
+    Map<String, Function> functions = functionLoader.listFunctions(Thread.currentThread().getContextClassLoader(), Version.LATEST, scope);
+    for (String name : functions.keySet())
+    {
+      scope.addFunction(name, functions.get(name));
+    }
+
     scope.setValue(SCOPE_NAME, mapper.valueToTree(filtered));
     return scope;
   }

--- a/interlok-jq/src/main/java/com/adaptris/core/json/jq/JsonJqTransform.java
+++ b/interlok-jq/src/main/java/com/adaptris/core/json/jq/JsonJqTransform.java
@@ -15,19 +15,6 @@
 */
 package com.adaptris.core.json.jq;
 
-import static com.adaptris.core.MetadataCollection.asMap;
-
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.ServiceLoader;
-
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -45,16 +32,21 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-
 import net.thisptr.jackson.jq.BuiltinFunctionLoader;
 import net.thisptr.jackson.jq.Function;
 import net.thisptr.jackson.jq.JsonQuery;
-import net.thisptr.jackson.jq.Output;
 import net.thisptr.jackson.jq.Scope;
 import net.thisptr.jackson.jq.Version;
-import net.thisptr.jackson.jq.exception.JsonQueryException;
-import net.thisptr.jackson.jq.internal.BuiltinFunction;
-import net.thisptr.jackson.jq.internal.JsonQueryFunction;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.adaptris.core.MetadataCollection.asMap;
 
 /**
  * Transform a JSON document using JQ style syntax.
@@ -175,15 +167,11 @@ public class JsonJqTransform extends ServiceImp {
   private Scope createScope(ObjectMapper mapper, AdaptrisMessage msg) {
     Map<String, String> filtered = asMap(metadataFilter().filter(msg));
     Scope scope = Scope.newEmptyScope();
-
-    //scope.loadFunctions(Thread.currentThread().getContextClassLoader());
     BuiltinFunctionLoader functionLoader = BuiltinFunctionLoader.getInstance();
     Map<String, Function> functions = functionLoader.listFunctions(Thread.currentThread().getContextClassLoader(), Version.LATEST, scope);
-    for (String name : functions.keySet())
-    {
+    for (String name : functions.keySet()) {
       scope.addFunction(name, functions.get(name));
     }
-
     scope.setValue(SCOPE_NAME, mapper.valueToTree(filtered));
     return scope;
   }

--- a/interlok-jslt/src/main/java/com/adaptris/core/json/jslt/JsltQuery.java
+++ b/interlok-jslt/src/main/java/com/adaptris/core/json/jslt/JsltQuery.java
@@ -39,7 +39,7 @@ public interface JsltQuery {
   /**
    * Turn an {@code AdaptrisMessage} object into a {@code JsonNode}.
    * <p>
-   * It first checks to see if {@value #INPUT_NODE_METADATA_KEY} exists in object metadata and uses
+   * It first checks to see if {@link #INPUT_NODE_METADATA_KEY} exists in object metadata and uses
    * that if it does. Otherwise it delegates to {@link #jacksonify(AdaptrisMessage)}.
    *
    * @param msg the {@link AdaptrisMessage}

--- a/interlok-json-streaming/src/main/java/com/adaptris/core/json/streaming/JsonPathStreamingService.java
+++ b/interlok-json-streaming/src/main/java/com/adaptris/core/json/streaming/JsonPathStreamingService.java
@@ -44,7 +44,7 @@ import lombok.Setter;
  * information on how to build a JSON path see the
  * <a href="https://github.com/jayway/JsonPath">JSONPath</a>
  * documentation and the
- * <a href="https://github.com/jsurfer/JsonSurfer">JSON Surfer</>
+ * <a href="https://github.com/jsurfer/JsonSurfer">JSON Surfer</a>
  * documentation.
  * </p>
  * For example, if you have a message with the following payload:

--- a/interlok-json/src/main/java/com/adaptris/core/services/splitter/json/JsonObjectSplitter.java
+++ b/interlok-json/src/main/java/com/adaptris/core/services/splitter/json/JsonObjectSplitter.java
@@ -30,7 +30,7 @@ import net.minidev.json.parser.JSONParser;
  * </p>
  * <p>
  * For instance the JSON Object <code>
-{"entry":[{"location":"Seattle","name":"Production System"},{"location":"New York","name":"R&D sandbox"}],"notes":"Some Notes","version":0.5}</code>
+{"entry":[{"location":"Seattle","name":"Production System"},{"location":"New York","name":"R&mp;D sandbox"}],"notes":"Some Notes","version":0.5}</code>
  * would be split into 3 messages (the {@code entry}, {@code notes} and {@code version}). JSON arrays will be split so that each
  * element of the array becomes a separate message, so <code>
 [{colour: "red",value: "#f00"},{colour: "green",value: "#0f0"},{colour: "blue",value: "#00f"},{colour: "black",value: "#000"}]</code>

--- a/interlok-json/src/main/java/com/adaptris/core/services/splitter/json/LargeJsonArrayPathSplitter.java
+++ b/interlok-json/src/main/java/com/adaptris/core/services/splitter/json/LargeJsonArrayPathSplitter.java
@@ -27,7 +27,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * </p>
  *
  * <p>
- * Note: tested with an 85Mb file containing an array of >15k JSON objects
+ * Note: tested with an 85Mb file containing an array of &gt;15k JSON objects
  * </p>
  *
  * @config large-json-array-path-splitter

--- a/interlok-json/src/main/java/com/adaptris/core/services/splitter/json/LargeJsonArraySplitter.java
+++ b/interlok-json/src/main/java/com/adaptris/core/services/splitter/json/LargeJsonArraySplitter.java
@@ -23,7 +23,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * Split an arbitrarily large JSON array.
  *
  * <p>
- * Note: tested with an 85Mb file containing an array of >15k JSON objects
+ * Note: tested with an 85Mb file containing an array of &gt;15k JSON objects
  * </p>
  *
  * @config large-json-array-splitter

--- a/interlok-json/src/main/java/com/adaptris/core/transform/json/JsonTransformService.java
+++ b/interlok-json/src/main/java/com/adaptris/core/transform/json/JsonTransformService.java
@@ -53,7 +53,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * <li>file-data-input-parameter {@link com.adaptris.core.common.FileDataInputParameter}</li>
  * <li>string-payload-data-input-parameter {@link com.adaptris.core.common.StringPayloadDataInputParameter}</li>
  * <li>metadata-data-input-parameter {@link com.adaptris.core.common.MetadataDataInputParameter}</li>
- * <li>metadata-file-input-parameter {@link com.adaptris.core.common.MetadataFileInputParameter}</li>
+ * <li>metadata-stream-input-parameter {@link com.adaptris.core.common.MetadataStreamInputParameter}</li>
  * </ul>
  * </p>
  * <p>
@@ -574,7 +574,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * Walk the input data, and Shiftr spec simultaneously, and execute the Shiftr command/mapping each time there is a match.
  * </p>
  *
- * <h3.Algorithm Low Level</h3>
+ * <h3>Algorithm Low Level</h3>
  * <ul>
  * <li>Simultaneously walk of the spec and input JSon, and maintain a walked "input" path data structure.</li>
  * <li>Determine a match between input JSON key and LHS spec, by matching LHS spec keys in the following order :

--- a/interlok-json/src/main/java/com/adaptris/core/transform/json/SafeJsonTransformationDriver.java
+++ b/interlok-json/src/main/java/com/adaptris/core/transform/json/SafeJsonTransformationDriver.java
@@ -22,16 +22,15 @@ import com.adaptris.core.util.ExceptionHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
- * Alternative to {@link DefaultJsonTransformationDriver} that executes a transform to strip-spaces before rendering as JSON.
+ * Executes a transform to strip-spaces before rendering as JSON.
  * <p>
- * This differs from {@link DefaultJsonTransformationDriver} in that it will execute a transform to strip spaces using the standard
- * {@code xsl:strip-space elements="*"} directive before attempting to serialize the XML as JSON. In some situations the default
+ * This will execute a transform to strip spaces using the standard {@code xsl:strip-space elements="*"}
+ * directive before attempting to serialize the XML as JSON. In some situations the default
  * driver can be very sensitive to whitespace that may occur because of indenting and formatting.
  * </p>
  * <p>
  * The transform used is stored in the jar file itself - {@value #STRIP_SPACES_XSLT}; it is very simple, and may not handle
- * namespaces terribly well. If in doubt, execute a transform yourslef, and then use {@link DefaultJsonTransformationDriver} as
- * usual.
+ * namespaces terribly well.
  * </p>
  * 
  * @since 3.6.4

--- a/interlok-json/src/main/java/com/adaptris/core/transform/json/SimpleJsonTransformationDriver.java
+++ b/interlok-json/src/main/java/com/adaptris/core/transform/json/SimpleJsonTransformationDriver.java
@@ -21,8 +21,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * tag as the root element of the XML.
  * </p>
  * <p>
- * If your input is a relatively JSON object, then this is the transformation driver to use; {@link DefaultJsonTransformationDriver}
- * adds a layer of XML complexity that you may not need. The key differentiator is that where the output <strong>should be</strong>
+ * If your input is a relatively JSON object, then this is the transformation driver to use.
+ * The key differentiator is that where the output <strong>should be</strong>
  * a JSON array with a single element; it will not be supported by this driver implementation. You can still use it, but you will
  * have to execute a {@link JsonTransformService} afterwards to change the cardinality.
  * </p>

--- a/interlok-json/src/main/java/com/adaptris/core/transform/json/TransformationDirection.java
+++ b/interlok-json/src/main/java/com/adaptris/core/transform/json/TransformationDirection.java
@@ -3,7 +3,7 @@ package com.adaptris.core.transform.json;
 import com.adaptris.annotation.InputFieldHint;
 
 /**
- * Direction enum; JSON <-> XML.
+ * Direction enum; JSON &lt;-&gt; XML.
  */
 public enum TransformationDirection {
 	/**


### PR DESCRIPTION
## Motivation

There is now a preview release of JQ version 1. As it is incompatible with previous releases it is worth seeing how much is going to need changing in interlok-jsjon-jq.

## Modification

Update the dependency in build.gradle and update usage in the JsonJqTransform class.

## PR Checklist

- [x] been self-reviewed.
- [x] Checked that new 3rd party dependencies are appropriately licensed
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI

## Result

There should be no noticeable change for the end user.

## Testing

[Simple config](https://github.com/adaptris/interlok-json/files/7177860/adapter.xml.txt) that demonstrates no change for end user.

