### PR TITLE
Fix snyk.io vulnerability reports in gson + junit.

### DIFF
--- a/interlok-json-streaming/build.gradle
+++ b/interlok-json-streaming/build.gradle
@@ -12,22 +12,23 @@ dependencies {
   api ("com.adaptris:interlok-stax:$interlokCoreVersion") { changing= true}
   api ("de.odysseus.staxon:staxon:1.3")
 
-  api("com.github.jsurfer:jsurfer-gson:$jsonSurferVersion")
+  api("com.github.jsurfer:jsurfer-core:$jsonSurferVersion")
+  api("com.github.jsurfer:jsurfer-gson:$jsonSurferVersion") {
+    exclude group: "com.google.code.gson", module: "gson"
+  }
+  implementation ("com.google.code.gson:gson:2.8.9")
   api("com.github.jsurfer:jsurfer-jackson:$jsonSurferVersion") {
     exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
     exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
     exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
   }
-  // compile("com.github.jsurfer:jsurfer-fastjson:$jsonSurferVersion") {
-  //   exclude group: "com.alibaba", module: "fastjson"
-  // }
-  api ("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
-  api ("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
-  api ("com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion")
-
-  // compile("com.alibaba:fastjson:1.2.76")
-  api("com.github.jsurfer:jsurfer-jsonsimple:$jsonSurferVersion")
-
+  api("com.github.jsurfer:jsurfer-jsonsimple:$jsonSurferVersion") {
+    exclude group: "junit", module: "junit"
+  }
+  
+  implementation ("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
+  implementation ("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
+  implementation ("com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion")
   testImplementation("org.skyscreamer:jsonassert:1.5.0")
   testImplementation ("com.jayway.jsonpath:json-path:2.6.0")
 


### PR DESCRIPTION
## Motivation

snyk.io has reported vulns in gson + junit.

- https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327
- https://security.snyk.io/vuln/SNYK-JAVA-JUNIT-1017047

junit should never be a runtime dependency anyway.

## Modification

- Remove transitive dependency on junit which was awful anyway.
- Add exclusion for gson, and opt for explicit dependency.

## PR Checklist

- [x] been self-reviewed.

## Result

No change for the end user.

## Testing

Tests pass; inspect the snyk.io report in the checks for this PR.
