### PR TITLE
INTERLOK-3852 Use long instead of integer

### DIFF
--- a/interlok-json/src/main/java/com/adaptris/core/transform/json/XMLSerializer.java
+++ b/interlok-json/src/main/java/com/adaptris/core/transform/json/XMLSerializer.java
@@ -1212,9 +1212,9 @@ class XMLSerializer {
       if (type.compareToIgnoreCase(JSONTypes.BOOLEAN) == 0) {
         setOrAccumulate(jsonObject, key, Boolean.valueOf(element.getValue()));
       } else if (type.compareToIgnoreCase(JSONTypes.NUMBER) == 0) {
-        // try integer first
+        // try Long first
         try {
-          setOrAccumulate(jsonObject, key, Integer.valueOf(element.getValue()));
+          setOrAccumulate(jsonObject, key, Long.valueOf(element.getValue()));
         } catch (NumberFormatException e) {
           setOrAccumulate(jsonObject, key, Double.valueOf(element.getValue()));
         }

--- a/interlok-json/src/test/java/com/adaptris/core/transform/json/JsonXmlTransformServiceTest.java
+++ b/interlok-json/src/test/java/com/adaptris/core/transform/json/JsonXmlTransformServiceTest.java
@@ -1,14 +1,5 @@
 package com.adaptris.core.transform.json;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import java.util.Arrays;
-import java.util.List;
-import org.json.JSONArray;
-import org.json.JSONObject;
-import org.junit.Test;
-import org.w3c.dom.Document;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ServiceException;
@@ -16,6 +7,17 @@ import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 import com.adaptris.core.util.XmlHelper;
 import com.adaptris.interlok.junit.scaffolding.services.TransformServiceExample;
 import com.adaptris.util.text.xml.XPath;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class JsonXmlTransformServiceTest extends TransformServiceExample {
 
@@ -58,6 +60,14 @@ public class JsonXmlTransformServiceTest extends TransformServiceExample {
       "[ { \"$type\": \"Tfl.Api.Presentation.Entities.Line, Tfl.Api.Presentation.Entities\", " + "\"id\": \"victoria\", "
           + "\"name\": \"Victoria\", " + "\"modeName\": \"tube\", " + "\"created\": \"2015-07-23T14:35:19.787\", "
           + "\"modified\": \"2015-07-23T14:35:19.787\", " + "\"lineStatuses\": [], " + "\"routeSections\": [] }]";
+
+  static final String LONGER_THAN_INT_XML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<outputresult class=\"object\">\n"
+        + "<systemresponse class=\"object\">\n<records class=\"array\">\n<responsearrayelement class=\"object\">\n"
+        + "<record type=\"number\">1</record>\n<resultid type=\"number\">123456789112</resultid>\n"
+        + "<runid type=\"number\">12345</runid>\n</responsearrayelement>\n</records>\n</systemresponse>\n</outputresult>";
+  static final String LONGER_THAN_INT_JSON = "{\"record\":1,\"resultid\":123456789112,\"runid\":12345}";
+  static final String LONGER_THAN_INT_JSON_OUTPUT = "[[[" + LONGER_THAN_INT_JSON + "]]]";
+  static final String LONGER_THAN_INT_XML_OUTPUT = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<outputresult><record type=\"number\">1</record><resultid type=\"number\">123456789112</resultid><runid type=\"number\">12345</runid></outputresult>\r\n";
 
   @Test
   public void testTransformToXml() throws Exception {
@@ -134,6 +144,36 @@ public class JsonXmlTransformServiceTest extends TransformServiceExample {
     svc.setDriver(new SimpleJsonTransformationDriver());
     execute(svc, msg);
     doJsonAssertions(msg);
+  }
+
+  @Test
+  public void testLongIntegerValuesXmlToJson() throws Exception
+  {
+    final AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(LONGER_THAN_INT_XML);
+    final JsonXmlTransformService service = new JsonXmlTransformService();
+    service.setDirection(TransformationDirection.XML_TO_JSON);
+    JsonObjectTransformationDriver driver = new JsonObjectTransformationDriver();
+    driver.setRootName("outputresult");
+    driver.setArrayName("responsearray");
+    driver.setElementName("responsearrayelement");
+    service.setDriver(driver);
+    execute(service, message);
+    assertEquals(LONGER_THAN_INT_JSON_OUTPUT, message.getContent());
+  }
+
+  @Test
+  public void testLongIntegerValuesJsonToXml() throws Exception
+  {
+    final AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(LONGER_THAN_INT_JSON);
+    final JsonXmlTransformService service = new JsonXmlTransformService();
+    service.setDirection(TransformationDirection.JSON_TO_XML);
+    JsonObjectTransformationDriver driver = new JsonObjectTransformationDriver();
+    driver.setRootName("outputresult");
+    driver.setArrayName("responsearray");
+    driver.setElementName("responsearrayelement");
+    service.setDriver(driver);
+    execute(service, message);
+    assertEquals(LONGER_THAN_INT_XML_OUTPUT, message.getContent());
   }
 
   @Override


### PR DESCRIPTION
## Motivation

Sufficiently large Integers get converted to Double and then expressed in scientific notation when converting from XML to JSON.

## Modification

Instead of using an Integer, the conversion now uses a Long. Also, add unit tests (which seem to suggest that it isn't such a problem converting from JSON to XML).

## PR Checklist

- [x] been self-reviewed.
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance

## Result

Values too large for an Integer don't get converted to a Double and end up in scientific notation.

## Testing

[This config](https://github.com/adaptris/interlok-json/files/7677423/adapter.xml.txt) can be used to highlight the error, and then the solution.

