### PR TITLE
interlok-2752 Add new JSON resolver

### DIFF
--- a/interlok-json/src/main/java/com/adaptris/core/json/resolver/SaferJSONResolver.java
+++ b/interlok-json/src/main/java/com/adaptris/core/json/resolver/SaferJSONResolver.java
@@ -1,0 +1,164 @@
+package com.adaptris.core.json.resolver;
+
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.core.json.JacksonJsonDeserializer;
+import com.adaptris.core.json.JsonDeserializer;
+import com.adaptris.interlok.resolver.FileResolver;
+import com.adaptris.interlok.resolver.ResolverImp;
+import com.adaptris.interlok.resolver.UnresolvableException;
+import com.adaptris.interlok.types.InterlokMessage;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.ObjectUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Resolver implementation that resolves and escapes JSON content.
+ * <p>
+ * This resolver resolves values based on the following:
+ * %resolveJson{...}, and will place the result in a a JSON node with
+ * the correct escaping, particularly of quotation marks.
+ * </p>
+ */
+public class SaferJSONResolver extends ResolverImp
+{
+	private static final Logger log = LoggerFactory.getLogger(FileResolver.class);
+
+	private static final String RESOLVE_REGEXP = "^.*%resolveJson\\{(.+)\\}.*$";
+	private final transient Pattern resolverPattern;
+
+	@Getter
+	@Setter
+	@AdvancedConfig(rare = true)
+	private JsonDeserializer<JsonNode> jsonDeserializer;
+
+	public SaferJSONResolver()
+	{
+		resolverPattern = Pattern.compile(RESOLVE_REGEXP, Pattern.DOTALL);
+	}
+
+	/**
+	 * {@inheritDoc}.
+	 */
+	@Override
+	public String resolve(String lookupValue)
+	{
+		throw new UnresolvableException("Safer XML resolver requires a target message!");
+	}
+
+	/**
+	 * {@inheritDoc}.
+	 */
+	@Override
+	public String resolve(String lookupValue, InterlokMessage target)
+	{
+		if (target == null)
+		{
+			throw new UnresolvableException("Target message cannot be null!");
+		}
+		if (lookupValue == null)
+		{
+			lookupValue = target.getContent();
+		}
+		String result = lookupValue;
+		log.trace("Resolving {} from JSON", lookupValue);
+		try
+		{
+			JsonNode json = jsonDeserializer().deserialize(lookupValue);
+			checkJsonObject(target, json);
+			result = json.toString();
+		}
+		catch (Exception e)
+		{
+			log.error("Could not parse JSON!", e);
+			throw new UnresolvableException(e);
+		}
+		return result;
+	}
+
+	/**
+	 * {@inheritDoc}.
+	 */
+	@Override
+	public boolean canHandle(String value)
+	{
+		return resolverPattern.matcher(value).matches();
+	}
+
+	private JsonDeserializer<JsonNode> jsonDeserializer()
+	{
+		return ObjectUtils.defaultIfNull(jsonDeserializer, new JacksonJsonDeserializer());
+	}
+
+	/*
+	 * It's done this way because trying to use a regex like
+	 * %resolveJson{...} within a JSON document leads to madness: do
+	 * you try to match the fewest characters before '}' (in which case
+	 * you cannot support embedded resolvers such as
+	 * %resolveJson{%message{...}} or do you go greedy and then start
+	 * matching any '}' that's actually part of the document? Madness I
+	 * tell you.
+	 */
+	private void checkJsonObject(InterlokMessage target, JsonNode node)
+	{
+		log.debug("Node {}", node.asText());
+		Iterator<String> iter = node.fieldNames();
+		List<String> remove = new ArrayList<>();
+		while (iter.hasNext())
+		{
+			String key = iter.next();
+			JsonNode item = node.get(key);
+
+			String k2 = replaceMatch(target, key);
+			if (!k2.equals(key))
+			{
+				remove.add(key);
+				key = k2;
+			}
+			if (item.isObject())
+			{
+				checkJsonObject(target, item);
+			}
+			else
+			{
+				String result = item.textValue();
+				if (result != null)
+				{
+					result = replaceMatch(target, result);
+					((ObjectNode)node).set(key, new TextNode(result));
+				}
+			}
+		}
+		for (String r : remove)
+		{
+			((ObjectNode)node).remove(r);
+		}
+		return;
+	}
+
+	private String replaceMatch(InterlokMessage target, String search)
+	{
+		String result = search;
+		Matcher matcher = resolverPattern.matcher(result);
+		while (matcher.matches())
+		{
+			String replace = matcher.group(1);
+			String value = target.resolve(replace);
+			log.trace("Found value {} within target message", value);
+			String toReplace = "%resolveJson{" + replace + "}";
+			result = result.replace(toReplace, value);
+			matcher = resolverPattern.matcher(result);
+		}
+		return target.resolve(result);
+	}
+}

--- a/interlok-json/src/main/java/com/adaptris/core/json/resolver/SaferJSONResolver.java
+++ b/interlok-json/src/main/java/com/adaptris/core/json/resolver/SaferJSONResolver.java
@@ -76,7 +76,7 @@ public class SaferJSONResolver extends ResolverImp
 		{
 			JsonNode json = jsonDeserializer().deserialize(lookupValue);
 			checkJsonObject(target, json);
-			result = json.toString();
+			result = json.toPrettyString();
 		}
 		catch (Exception e)
 		{

--- a/interlok-json/src/main/java/com/adaptris/core/json/resolver/SaferJSONResolver.java
+++ b/interlok-json/src/main/java/com/adaptris/core/json/resolver/SaferJSONResolver.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,10 +31,9 @@ import java.util.regex.Pattern;
  * the correct escaping, particularly of quotation marks.
  * </p>
  */
+@Slf4j
 public class SaferJSONResolver extends ResolverImp
 {
-	private static final Logger log = LoggerFactory.getLogger(FileResolver.class);
-
 	private static final String RESOLVE_REGEXP = "^.*%resolveJson\\{(.+)\\}.*$";
 	private final transient Pattern resolverPattern;
 

--- a/interlok-json/src/main/java/com/adaptris/core/json/resolver/SaferJSONResolver.java
+++ b/interlok-json/src/main/java/com/adaptris/core/json/resolver/SaferJSONResolver.java
@@ -34,7 +34,7 @@ import java.util.regex.Pattern;
 @Slf4j
 public class SaferJSONResolver extends ResolverImp
 {
-	private static final String RESOLVE_REGEXP = "^.*%resolveJson\\{(.+)\\}.*$";
+	private static final String RESOLVE_REGEXP = "^.*%asJSONString\\{(.+)\\}.*$";
 	private final transient Pattern resolverPattern;
 
 	@Getter
@@ -155,7 +155,7 @@ public class SaferJSONResolver extends ResolverImp
 			String replace = matcher.group(1);
 			String value = target.resolve(replace);
 			log.trace("Found value {} within target message", value);
-			String toReplace = "%resolveJson{" + replace + "}";
+			String toReplace = "%asJSONString{" + replace + "}";
 			result = result.replace(toReplace, value);
 			matcher = resolverPattern.matcher(result);
 		}

--- a/interlok-json/src/main/java/com/adaptris/core/json/resolver/SaferJSONResolver.java
+++ b/interlok-json/src/main/java/com/adaptris/core/json/resolver/SaferJSONResolver.java
@@ -3,7 +3,6 @@ package com.adaptris.core.json.resolver;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.core.json.JacksonJsonDeserializer;
 import com.adaptris.core.json.JsonDeserializer;
-import com.adaptris.interlok.resolver.FileResolver;
 import com.adaptris.interlok.resolver.ResolverImp;
 import com.adaptris.interlok.resolver.UnresolvableException;
 import com.adaptris.interlok.types.InterlokMessage;
@@ -14,8 +13,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -27,7 +24,7 @@ import java.util.regex.Pattern;
  * Resolver implementation that resolves and escapes JSON content.
  * <p>
  * This resolver resolves values based on the following:
- * %resolveJson{...}, and will place the result in a a JSON node with
+ * %asJSONString{...}, and will place the result in a a JSON node with
  * the correct escaping, particularly of quotation marks.
  * </p>
  */
@@ -102,10 +99,10 @@ public class SaferJSONResolver extends ResolverImp
 
 	/*
 	 * It's done this way because trying to use a regex like
-	 * %resolveJson{...} within a JSON document leads to madness: do
+	 * %asJSONString{...} within a JSON document leads to madness: do
 	 * you try to match the fewest characters before '}' (in which case
 	 * you cannot support embedded resolvers such as
-	 * %resolveJson{%message{...}} or do you go greedy and then start
+	 * %asJSONString{%message{...}} or do you go greedy and then start
 	 * matching any '}' that's actually part of the document? Madness I
 	 * tell you.
 	 */

--- a/interlok-json/src/main/resources/META-INF/services/com.adaptris.interlok.resolver.Resolver
+++ b/interlok-json/src/main/resources/META-INF/services/com.adaptris.interlok.resolver.Resolver
@@ -1,1 +1,2 @@
 com.adaptris.core.json.resolver.FromPayloadUsingJSONPath
+com.adaptris.core.json.resolver.SaferJSONResolver

--- a/interlok-json/src/test/java/com/adaptris/core/json/resolver/SaferJSONResolverTest.java
+++ b/interlok-json/src/test/java/com/adaptris/core/json/resolver/SaferJSONResolverTest.java
@@ -1,13 +1,13 @@
 package com.adaptris.core.json.resolver;
 
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.interlok.resolver.UnresolvableException;
-import net.sf.json.JSONObject;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-import static org.junit.Assert.assertTrue;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.interlok.resolver.UnresolvableException;
 
 public class SaferJSONResolverTest
 {

--- a/interlok-json/src/test/java/com/adaptris/core/json/resolver/SaferJSONResolverTest.java
+++ b/interlok-json/src/test/java/com/adaptris/core/json/resolver/SaferJSONResolverTest.java
@@ -23,7 +23,7 @@ public class SaferJSONResolverTest
 			"    \"state\": \"NY\",\n" +
 			"    \"postalCode\": \"10021-3100\"\n" +
 			"  },\n" +
-			"  \"%message{key}\": \"%resolveJson{%message{" + KEY + "}}\"\n" +
+			"  \"%message{key}\": \"%asJSONString{%message{" + KEY + "}}\"\n" +
 			"}";
 	private static final String JSON_RESOLVED = "{\n" +
 			"  \"firstName\" : \"John\",\n" +

--- a/interlok-json/src/test/java/com/adaptris/core/json/resolver/SaferJSONResolverTest.java
+++ b/interlok-json/src/test/java/com/adaptris/core/json/resolver/SaferJSONResolverTest.java
@@ -1,0 +1,83 @@
+package com.adaptris.core.json.resolver;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.interlok.resolver.UnresolvableException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SaferJSONResolverTest
+{
+	private static final String KEY = "greeting";
+	private static final String GREETING = "Hello \"JSON resolver test\"";
+	private static final String JSON_SOURCE = "{\n" +
+			"  \"firstName\": \"John\",\n" +
+			"  \"lastName\": \"Smith\",\n" +
+			"  \"isAlive\": true,\n" +
+			"  \"age\": 27,\n" +
+			"  \"address\": {\n" +
+			"    \"streetAddress\": \"21 2nd Street\",\n" +
+			"    \"city\": \"New York\",\n" +
+			"    \"state\": \"NY\",\n" +
+			"    \"postalCode\": \"10021-3100\"\n" +
+			"  },\n" +
+			"  \"%message{key}\": \"%resolveJson{%message{" + KEY + "}}\"\n" +
+			"}";
+	private static final String JSON_RESOLVED = "{\"firstName\":\"John\",\"lastName\":\"Smith\",\"isAlive\":true,\"age\":27,\"address\":{\"streetAddress\":\"21 2nd Street\",\"city\":\"New York\",\"state\":\"NY\",\"postalCode\":\"10021-3100\"},\"greeting\":\"Hello \\\"JSON resolver test\\\"\"}";
+
+	@Test
+	public void testCanResolve()
+	{
+		assertTrue(new SaferJSONResolver().canHandle(JSON_SOURCE));
+	}
+
+	@Test
+	public void testResolve()
+	{
+		AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+		message.addMetadata(KEY, GREETING);
+		message.addMetadata("key", KEY);
+		SaferJSONResolver resolver = new SaferJSONResolver();
+		String result = resolver.resolve(JSON_SOURCE, message);
+		assertEquals(JSON_RESOLVED, result);
+	}
+
+	@Test
+	public void testResolveMessageContent()
+	{
+		AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON_SOURCE);
+		message.addMetadata(KEY, GREETING);
+		message.addMetadata("key", KEY);
+		SaferJSONResolver resolver = new SaferJSONResolver();
+		String result = resolver.resolve(null, message);
+		assertEquals(JSON_RESOLVED, result);
+	}
+
+	@Test(expected = UnresolvableException.class)
+	public void testResolveNoValue()
+	{
+		AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+		SaferJSONResolver resolver = new SaferJSONResolver();
+		resolver.resolve(JSON_SOURCE, message);
+	}
+
+	@Test(expected = UnresolvableException.class)
+	public void testNoMessage()
+	{
+		new SaferJSONResolver().resolve(JSON_SOURCE);
+	}
+
+	@Test(expected = UnresolvableException.class)
+	public void testNullMessage()
+	{
+		new SaferJSONResolver().resolve(JSON_SOURCE, null);
+	}
+
+	@Test(expected = UnresolvableException.class)
+	public void testNullExpression()
+	{
+		new SaferJSONResolver().resolve(null, null);
+	}
+}

--- a/interlok-json/src/test/java/com/adaptris/core/json/resolver/SaferJSONResolverTest.java
+++ b/interlok-json/src/test/java/com/adaptris/core/json/resolver/SaferJSONResolverTest.java
@@ -3,6 +3,7 @@ package com.adaptris.core.json.resolver;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.interlok.resolver.UnresolvableException;
+import net.sf.json.test.JSONAssert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -53,7 +54,7 @@ public class SaferJSONResolverTest
 		message.addMetadata("key", KEY);
 		SaferJSONResolver resolver = new SaferJSONResolver();
 		String result = resolver.resolve(JSON_SOURCE, message);
-		assertEquals(JSON_RESOLVED, result);
+		JSONAssert.assertEquals(JSON_RESOLVED, result);
 	}
 
 	@Test
@@ -64,7 +65,7 @@ public class SaferJSONResolverTest
 		message.addMetadata("key", KEY);
 		SaferJSONResolver resolver = new SaferJSONResolver();
 		String result = resolver.resolve(null, message);
-		assertEquals(JSON_RESOLVED, result);
+		JSONAssert.assertEquals(JSON_RESOLVED, result);
 	}
 
 	@Test(expected = UnresolvableException.class)

--- a/interlok-json/src/test/java/com/adaptris/core/json/resolver/SaferJSONResolverTest.java
+++ b/interlok-json/src/test/java/com/adaptris/core/json/resolver/SaferJSONResolverTest.java
@@ -3,10 +3,10 @@ package com.adaptris.core.json.resolver;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.interlok.resolver.UnresolvableException;
-import net.sf.json.test.JSONAssert;
+import net.sf.json.JSONObject;
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class SaferJSONResolverTest
@@ -54,7 +54,7 @@ public class SaferJSONResolverTest
 		message.addMetadata("key", KEY);
 		SaferJSONResolver resolver = new SaferJSONResolver();
 		String result = resolver.resolve(JSON_SOURCE, message);
-		JSONAssert.assertEquals(JSON_RESOLVED, result);
+		JSONAssert.assertEquals(JSON_RESOLVED, result, false);
 	}
 
 	@Test
@@ -65,7 +65,7 @@ public class SaferJSONResolverTest
 		message.addMetadata("key", KEY);
 		SaferJSONResolver resolver = new SaferJSONResolver();
 		String result = resolver.resolve(null, message);
-		JSONAssert.assertEquals(JSON_RESOLVED, result);
+		JSONAssert.assertEquals(JSON_RESOLVED, result, false);
 	}
 
 	@Test(expected = UnresolvableException.class)

--- a/interlok-json/src/test/java/com/adaptris/core/json/resolver/SaferJSONResolverTest.java
+++ b/interlok-json/src/test/java/com/adaptris/core/json/resolver/SaferJSONResolverTest.java
@@ -25,7 +25,19 @@ public class SaferJSONResolverTest
 			"  },\n" +
 			"  \"%message{key}\": \"%resolveJson{%message{" + KEY + "}}\"\n" +
 			"}";
-	private static final String JSON_RESOLVED = "{\"firstName\":\"John\",\"lastName\":\"Smith\",\"isAlive\":true,\"age\":27,\"address\":{\"streetAddress\":\"21 2nd Street\",\"city\":\"New York\",\"state\":\"NY\",\"postalCode\":\"10021-3100\"},\"greeting\":\"Hello \\\"JSON resolver test\\\"\"}";
+	private static final String JSON_RESOLVED = "{\n" +
+			"  \"firstName\" : \"John\",\n" +
+			"  \"lastName\" : \"Smith\",\n" +
+			"  \"isAlive\" : true,\n" +
+			"  \"age\" : 27,\n" +
+			"  \"address\" : {\n" +
+			"    \"streetAddress\" : \"21 2nd Street\",\n" +
+			"    \"city\" : \"New York\",\n" +
+			"    \"state\" : \"NY\",\n" +
+			"    \"postalCode\" : \"10021-3100\"\n" +
+			"  },\n" +
+			"  \"greeting\" : \"Hello \\\"JSON resolver test\\\"\"\n" +
+			"}";
 
 	@Test
 	public void testCanResolve()


### PR DESCRIPTION
## Motivation

What if the resolved data isn't safe for JSON? It should be escaped, particularly if there are quotation marks within the data.

## Modification

Add new resolver that will ensure that the resolved data is JSON safe.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI

## Result

(Hopefully) the user can now include whatever they want when resolving into a JSON document.

## Testing

[Sample config](https://github.com/adaptris/interlok-json/files/7821836/adapter.xml.txt) that will resolve metadata and insert in into the JSON payload. Used in combination with the [new XML resolver](https://github.com/adaptris/interlok/pull/867).

NB The config will need updating to use `%asJSONString{...}`