### PR TITLE
Switch to formal mavencentral artefact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,6 @@ subprojects {
     }
     maven { url "$nexusBaseUrl/content/groups/public" }
     maven { url "$nexusBaseUrl/content/groups/interlok" }
-    maven { url 'https://jitpack.io' }
   }
 
   configurations {

--- a/interlok-json/build.gradle
+++ b/interlok-json/build.gradle
@@ -29,7 +29,7 @@ dependencies {
   api ("commons-beanutils:commons-beanutils:1.9.4")
   implementation ("xerces:xercesImpl:2.12.2")
 
-  api ("com.github.everit-org.json-schema:org.everit.json.schema:1.14.0")
+  api ("com.github.erosb:everit-json-schema:1.14.0")
   implementation ("com.google.guava:guava:31.1-jre")
   api ("com.flipkart.zjsonpatch:zjsonpatch:0.4.12")
   testImplementation ("org.skyscreamer:jsonassert:1.5.0")


### PR DESCRIPTION
## Motivation

everit-json-schema has moved from jitpack to mavenCentral and into the group `com.github.erosb`
jitpack is still usable, but it may be better to rely on his formal release artifacts in case he decides not to build via github-release.

## Modification

Changed group-id / artifact name in interlok-json
Remove jitpack.io as a gradle repo.

## PR Checklist

- [x] been self-reviewed.

## Result

No change for the end user

## Testing

`gradle check` passes.
