### PR TITLE
fix(junit): Add missing method from API change

### DIFF
--- a/interlok-json/src/test/java/com/adaptris/core/json/resolver/FromPayloadUsingJSONPathTest.java
+++ b/interlok-json/src/test/java/com/adaptris/core/json/resolver/FromPayloadUsingJSONPathTest.java
@@ -51,6 +51,7 @@ public class FromPayloadUsingJSONPathTest
     @Override public boolean headersContainsKey(String key) { return false; }
     @Override public String resolve(String s, boolean multiline) { return null; }
     @Override public Object resolveObject(String s) { return null; }
+    @Override public void clearMessageHeaders() { }
 
     private String payload = DATA;
     private String encoding = "UTF-8";


### PR DESCRIPTION

## Motivation

Add changes required by https://github.com/adaptris/interlok/pull/950


## Modification

Fix unit test (the style is ashleys) that has an anonymous InterlokMessage impl.

## PR Checklist

- [x] been self-reviewed.

## Result

No change for the end user of Interlok

## Testing

`./gradlew compileTestJava` now works.
