### PR TITLE
Feature/interlok 4123 payload path encryption

### DIFF
--- a/interlok-json/src/main/java/com/adaptris/core/json/path/JsonPathBuilder.java
+++ b/interlok-json/src/main/java/com/adaptris/core/json/path/JsonPathBuilder.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import javax.validation.constraints.NotNull;
 
 import com.adaptris.annotation.AdapterComponent;
-import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldHint;
@@ -61,7 +60,6 @@ public class JsonPathBuilder implements PathBuilder {
   @Getter
   @Setter
   @NotNull
-  @AutoPopulated
   @XStreamImplicit(itemFieldName = "json-paths")
   @InputFieldHint(expression = true)
   private List<String> paths;
@@ -93,6 +91,7 @@ public class JsonPathBuilder implements PathBuilder {
         throw new ServiceException(String.format(JSON_INVALID_PATH_EXCEPTION_MESSAGE, jsonPathToExecute));
       }
     }
+    
     return pathKeyValuePairs;
   }
 
@@ -107,5 +106,4 @@ public class JsonPathBuilder implements PathBuilder {
     }
     msg.setContent(jsonDoc.jsonString(), msg.getContentEncoding());
   }
-
 }

--- a/interlok-json/src/main/java/com/adaptris/core/json/path/JsonPathBuilder.java
+++ b/interlok-json/src/main/java/com/adaptris/core/json/path/JsonPathBuilder.java
@@ -1,0 +1,110 @@
+package com.adaptris.core.json.path;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.validation.constraints.NotNull;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.AutoPopulated;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.security.PathBuilder;
+import com.adaptris.core.util.Args;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.InvalidPathException;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.PathNotFoundException;
+import com.jayway.jsonpath.ReadContext;
+import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+
+/**
+ * 
+ * @author jwickham
+ * 
+ *         Imp that expects a JSON path to be provided.
+ *
+ */
+
+@XStreamAlias("json-path-builder")
+@AdapterComponent
+@ComponentProfile(summary = "json builder to extract and insert", tag = "service,security,path", since = "4.8.9")
+@DisplayOrder(order = { "json-paths" })
+public class JsonPathBuilder implements PathBuilder {
+
+  private static final String JSON_PATH_NOT_FOUND_EXCEPTION_MESSAGE = "No results found for JSON path [%s]";
+  private static final String JSON_INVALID_PATH_EXCEPTION_MESSAGE = "Invalid Json path [%s]";
+  private static final String JSON_NON_OBJECT_PATH_EXCEPTION_MESSAGE = "Please ensure your path [%s] points to a single JSON object";
+  
+
+  public JsonPathBuilder() {
+    this.setPaths(new ArrayList<String>());
+  }
+
+  @Getter
+  @Setter
+  @NotNull
+  @AutoPopulated
+  @XStreamImplicit(itemFieldName = "json-paths")
+  private List<String> paths;
+
+  private Configuration jsonConfig = new Configuration.ConfigurationBuilder().jsonProvider(new JsonSmartJsonProvider())
+      .mappingProvider(new JacksonMappingProvider()).options(EnumSet.noneOf(Option.class)).build();
+
+  @Override
+  public void prepare() throws CoreException {
+    Args.notNull(getPaths(), "json-paths");
+  }
+  
+  @Override
+  public Map<String, String> extract(AdaptrisMessage msg) throws ServiceException {
+    String jsonString = msg.getContent();
+    ReadContext context = JsonPath.parse(jsonString, jsonConfig);
+    Map<String, String> pathKeyValuePairs = new LinkedHashMap<>();
+    for (String jsonPath : this.getPaths()) {
+      try {
+        Object result = context.read(jsonPath);
+        if (Map.class.isAssignableFrom(result.getClass()) || List.class.isAssignableFrom(result.getClass())) {
+          System.out.println(result.getClass());
+          throw new ServiceException(String.format(JSON_NON_OBJECT_PATH_EXCEPTION_MESSAGE, jsonPath));
+        }
+        System.out.println(result.getClass());
+        pathKeyValuePairs.put(jsonPath, result.toString());
+      } catch (PathNotFoundException e) {
+        throw new ServiceException(String.format(JSON_PATH_NOT_FOUND_EXCEPTION_MESSAGE, jsonPath));
+      } catch (InvalidPathException e) {
+        throw new ServiceException(String.format(JSON_INVALID_PATH_EXCEPTION_MESSAGE, jsonPath));
+      }
+    }
+    return pathKeyValuePairs;
+  }
+
+  @Override
+  public void insert(AdaptrisMessage msg, Map<String, String> pathKeyValuePairs) throws ServiceException {
+    String jsonString = msg.getContent();
+    DocumentContext jsonDoc = JsonPath.using(jsonConfig).parse(jsonString);
+    for (Map.Entry<String, String> entry : pathKeyValuePairs.entrySet()) {
+      String jsonKey = entry.getKey();
+      DocumentContext jsonValue = JsonPath.using(jsonConfig).parse(entry.getValue());
+      jsonDoc.set(jsonKey, jsonValue.json());
+    }
+    msg.setContent(jsonDoc.jsonString(), msg.getContentEncoding());
+  }
+
+}

--- a/interlok-json/src/main/java/com/adaptris/core/json/path/JsonPathBuilder.java
+++ b/interlok-json/src/main/java/com/adaptris/core/json/path/JsonPathBuilder.java
@@ -64,14 +64,9 @@ public class JsonPathBuilder implements PathBuilder {
   @InputFieldHint(expression = true)
   private List<String> paths;
 
-  private Configuration jsonConfig = new Configuration.ConfigurationBuilder().jsonProvider(new JsonSmartJsonProvider())
+  private transient Configuration jsonConfig = new Configuration.ConfigurationBuilder().jsonProvider(new JsonSmartJsonProvider())
       .mappingProvider(new JacksonMappingProvider()).options(EnumSet.noneOf(Option.class)).build();
 
-  @Override
-  public void prepare() throws CoreException {
-    Args.notNull(getPaths(), "json-paths");
-  }
-  
   @Override
   public Map<String, String> extract(AdaptrisMessage msg) throws ServiceException {
     String jsonString = msg.getContent();

--- a/interlok-json/src/main/java/com/adaptris/core/json/path/JsonPathBuilder.java
+++ b/interlok-json/src/main/java/com/adaptris/core/json/path/JsonPathBuilder.java
@@ -13,19 +13,10 @@ import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.security.PathBuilder;
 import com.adaptris.core.security.PayloadPathDecryptionService;
 import com.adaptris.core.security.PayloadPathEncryptionService;
-import com.adaptris.core.util.Args;
-import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
-import com.thoughtworks.xstream.annotations.XStreamAlias;
-import com.thoughtworks.xstream.annotations.XStreamImplicit;
-
-import lombok.Getter;
-import lombok.Setter;
-
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.InvalidPathException;
@@ -35,25 +26,31 @@ import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.ReadContext;
 import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Extracts and inserts values from message payload using defined Json Paths {@link String}.
  * <p>
- * This component simple extracts and inserts values from a JSON file using JSON paths.
- * While not coupled with {@link PayloadPathEncryptionService} and {@link PayloadPathDecryptionService} 
- * this component was built to be used with those two services.
- * 
- * <strong>It's important to note that to keep the JSON valid you can only configure a path to a single JSON object.
- * for example in the simple example below: 
+ * This component simple extracts and inserts values from a JSON file using JSON paths. While not coupled with
+ * {@link PayloadPathEncryptionService} and {@link PayloadPathDecryptionService} this component was built to be used with those two
+ * services.
+ *
+ * <strong>It's important to note that to keep the JSON valid you can only configure a path to a single JSON object. for example in the
+ * simple example below:
+ *
  * <pre>
  * {@code
  * {"name":"James", "age":30, "car":"Vauxhall"}
  * }
  * </pre>
- * You could define the following JSON path: "$.name".
- * </strong>
+ *
+ * You could define the following JSON path: "$.name". </strong>
  * </p>
- * 
+ *
  * @config json-path-builder
  *
  */
@@ -61,24 +58,23 @@ import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 @XStreamAlias("json-path-builder")
 @AdapterComponent
 @ComponentProfile(summary = "json builder to extract and insert", tag = "service,security,path", since = "5.0.0")
-@DisplayOrder(order = { "json-paths" })
+@DisplayOrder(order = { "json-path" })
 public class JsonPathBuilder implements PathBuilder {
 
   private static final String JSON_PATH_NOT_FOUND_EXCEPTION_MESSAGE = "No results found for JSON path [%s]";
   private static final String JSON_INVALID_PATH_EXCEPTION_MESSAGE = "Invalid Json path [%s]";
   private static final String JSON_NON_OBJECT_PATH_EXCEPTION_MESSAGE = "Please ensure your path [%s] points to a single JSON object";
-  
 
   public JsonPathBuilder() {
-    this.setPaths(new ArrayList<String>());
+    setJsonPaths(new ArrayList<>());
   }
 
   @Getter
   @Setter
   @NotNull
-  @XStreamImplicit(itemFieldName = "json-paths")
+  @XStreamImplicit(itemFieldName = "json-path")
   @InputFieldHint(expression = true)
-  private List<String> paths;
+  private List<String> jsonPaths;
 
   private transient Configuration jsonConfig = new Configuration.ConfigurationBuilder().jsonProvider(new JsonSmartJsonProvider())
       .mappingProvider(new JacksonMappingProvider()).options(EnumSet.noneOf(Option.class)).build();
@@ -88,7 +84,7 @@ public class JsonPathBuilder implements PathBuilder {
     String jsonString = msg.getContent();
     ReadContext context = JsonPath.parse(jsonString, jsonConfig);
     Map<String, String> pathKeyValuePairs = new LinkedHashMap<>();
-    for (String jsonPath : this.getPaths()) {
+    for (String jsonPath : getJsonPaths()) {
       try {
         Object result = context.read(msg.resolve(jsonPath));
         if (Map.class.isAssignableFrom(result.getClass()) || List.class.isAssignableFrom(result.getClass())) {
@@ -101,7 +97,7 @@ public class JsonPathBuilder implements PathBuilder {
         throw new ServiceException(String.format(JSON_INVALID_PATH_EXCEPTION_MESSAGE, msg.resolve(jsonPath)));
       }
     }
-    
+
     return pathKeyValuePairs;
   }
 
@@ -116,4 +112,5 @@ public class JsonPathBuilder implements PathBuilder {
     }
     msg.setContent(jsonDoc.jsonString(), msg.getContentEncoding());
   }
+
 }

--- a/interlok-json/src/main/java/com/adaptris/core/json/path/JsonPathBuilder.java
+++ b/interlok-json/src/main/java/com/adaptris/core/json/path/JsonPathBuilder.java
@@ -60,7 +60,7 @@ import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 
 @XStreamAlias("json-path-builder")
 @AdapterComponent
-@ComponentProfile(summary = "json builder to extract and insert", tag = "service,security,path", since = "4.8.9")
+@ComponentProfile(summary = "json builder to extract and insert", tag = "service,security,path", since = "5.0.0")
 @DisplayOrder(order = { "json-paths" })
 public class JsonPathBuilder implements PathBuilder {
 

--- a/interlok-json/src/test/java/com/adaptris/core/json/path/JsonPathBuilderTest.java
+++ b/interlok-json/src/test/java/com/adaptris/core/json/path/JsonPathBuilderTest.java
@@ -2,6 +2,7 @@ package com.adaptris.core.json.path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.booleanThat;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -60,6 +61,22 @@ public class JsonPathBuilderTest {
   public void testSingleObjectJsonPath() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON);
     jsonPath.add(JSON_FIRSTNAME_PATH);
+    jsonPathProvider.setPaths(jsonPath);
+    try {
+      resultKeyValuePairs = jsonPathProvider.extract(msg);
+      jsonPathProvider.insert(msg, resultKeyValuePairs);
+    } catch (ServiceException e) {
+      e.printStackTrace();
+      fail();
+    }
+    assertEquals(JSON, msg.getContent());
+  }
+  
+  @Test
+  public void testSingleObjectJsonPathFromMetadata() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON);
+    msg.addMetadata("jsonPath", JSON_FIRSTNAME_PATH);
+    jsonPath.add("%message{jsonPath}");
     jsonPathProvider.setPaths(jsonPath);
     try {
       resultKeyValuePairs = jsonPathProvider.extract(msg);

--- a/interlok-json/src/test/java/com/adaptris/core/json/path/JsonPathBuilderTest.java
+++ b/interlok-json/src/test/java/com/adaptris/core/json/path/JsonPathBuilderTest.java
@@ -1,6 +1,7 @@
 package com.adaptris.core.json.path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
@@ -34,10 +35,6 @@ public class JsonPathBuilderTest {
   private static final String JSON_EXPRESSION_PATH = "$.phoneNumbers.[0].number";
   private static final String JSON_INVALID_PATH = "invalid json path";
   private static final String JSON_NON_EXISTENT_PATH = "$.thirdName";
-
-  private static final String JSON_PATH_NOT_FOUND_EXCEPTION_MESSAGE = "No results found for JSON path [%s]";
-  private static final String JSON_INVALID_PATH_EXCEPTION_MESSAGE = "Invalid Json path [%s]";
-  private static final String JSON_NON_OBJECT_PATH_EXCEPTION_MESSAGE = "Please ensure your path [%s] points to a single JSON object";
   
   private static Map<String, String> resultKeyValuePairs;
   private static List<String> jsonPath;
@@ -124,10 +121,9 @@ public class JsonPathBuilderTest {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON);
     jsonPath.add(JSON_MULTI_OBJECT_PATH);
     jsonPathProvider.setPaths(jsonPath);
-    Throwable exception =  Assertions.assertThrows(ServiceException.class, () -> {
+    assertThrows(ServiceException.class, () -> {
       resultKeyValuePairs = jsonPathProvider.extract(msg);
-    });
-    assertEquals(String.format(JSON_NON_OBJECT_PATH_EXCEPTION_MESSAGE, JSON_MULTI_OBJECT_PATH), exception.getMessage());
+    }, "JSON path does not resolve to a single object.");
   }
   
   @Test
@@ -135,10 +131,9 @@ public class JsonPathBuilderTest {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON);
     jsonPath.add(JSON_ARRAY_PATH);
     jsonPathProvider.setPaths(jsonPath);
-    Throwable exception =  Assertions.assertThrows(ServiceException.class, () -> {
+    assertThrows(ServiceException.class, () -> {
       resultKeyValuePairs = jsonPathProvider.extract(msg);
-    });
-    assertEquals(String.format(JSON_NON_OBJECT_PATH_EXCEPTION_MESSAGE, JSON_ARRAY_PATH), exception.getMessage());
+    }, "JSON path does not resolve to a single object.");
   }
   
   @Test
@@ -146,10 +141,9 @@ public class JsonPathBuilderTest {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(NON_JSON);
     jsonPath.add(JSON_FIRSTNAME_PATH);
     jsonPathProvider.setPaths(jsonPath);
-    Throwable exception =  Assertions.assertThrows(ServiceException.class, () -> {
+    assertThrows(ServiceException.class, () -> {
       resultKeyValuePairs = jsonPathProvider.extract(msg);
-    });
-    assertEquals(String.format(JSON_PATH_NOT_FOUND_EXCEPTION_MESSAGE, JSON_FIRSTNAME_PATH), exception.getMessage());
+    }, "Non JSON message.");
   }
   
   @Test
@@ -157,10 +151,9 @@ public class JsonPathBuilderTest {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON);
     jsonPath.add(JSON_NON_EXISTENT_PATH);
     jsonPathProvider.setPaths(jsonPath);
-    Throwable exception =  Assertions.assertThrows(ServiceException.class, () -> {
+    assertThrows(ServiceException.class, () -> {
       resultKeyValuePairs = jsonPathProvider.extract(msg);
-    });
-    assertEquals(String.format(JSON_PATH_NOT_FOUND_EXCEPTION_MESSAGE, JSON_NON_EXISTENT_PATH), exception.getMessage());
+    }, "JSON path does not exist.");
   }
   
   @Test
@@ -168,10 +161,9 @@ public class JsonPathBuilderTest {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON);
     jsonPath.add(JSON_INVALID_PATH);
     jsonPathProvider.setPaths(jsonPath);
-    Throwable exception =  Assertions.assertThrows(ServiceException.class, () -> {
+    assertThrows(ServiceException.class, () -> {
       resultKeyValuePairs = jsonPathProvider.extract(msg);
-    });
-    assertEquals(String.format(JSON_INVALID_PATH_EXCEPTION_MESSAGE, JSON_INVALID_PATH), exception.getMessage());
+    }, "Invalid JSON path.");
   }
   
 }

--- a/interlok-json/src/test/java/com/adaptris/core/json/path/JsonPathBuilderTest.java
+++ b/interlok-json/src/test/java/com/adaptris/core/json/path/JsonPathBuilderTest.java
@@ -1,0 +1,161 @@
+package com.adaptris.core.json.path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.ServiceException;
+
+public class JsonPathBuilderTest {
+
+  private static final String JSON = "{\"firstName\":\"John\",\"lastName\":\"doe"
+      + "\",\"age\":26,\"address\":{\"streetAddress\":\"street\",\"city\":\"city\",\"postalCode"
+      + "\":\"TW12 3RR\"},\"phoneNumbers\":[{\"type\":\"mobile\",\"number\":\"000-000-000\"},"
+      + "{\"type\":\"home\",\"number\":\"111-111-111\"}]}";
+  
+  private static final String NON_JSON = "not json";
+
+  private static final String JSON_FIRSTNAME_PATH = "$.firstName";
+  private static final String JSON_LASTNAME_PATH = "$.lastName";
+  private static final String JSON_AGE_PATH = "$.age";
+  private static final String JSON_MULTI_OBJECT_PATH = "$.address";
+  private static final String JSON_ARRAY_PATH = "$.phoneNumbers";
+  private static final String JSON_EXPRESSION_PATH = "$.phoneNumbers.[0].number";
+  private static final String JSON_INVALID_PATH = "invalid json path";
+  private static final String JSON_NON_EXISTENT_PATH = "$.thirdName";
+
+  private static final String JSON_PATH_NOT_FOUND_EXCEPTION_MESSAGE = "No results found for JSON path [%s]";
+  private static final String JSON_INVALID_PATH_EXCEPTION_MESSAGE = "Invalid Json path [%s]";
+  private static final String JSON_NON_OBJECT_PATH_EXCEPTION_MESSAGE = "Please ensure your path [%s] points to a single JSON object";
+  
+  private static Map<String, String> resultKeyValuePairs;
+  private static List<String> jsonPath;
+  private static JsonPathBuilder jsonPathProvider;
+  
+  @BeforeAll
+  public static void setUp() {
+    resultKeyValuePairs  = new LinkedHashMap<>();
+    jsonPath = new ArrayList<String>();
+    jsonPathProvider = new JsonPathBuilder();
+  }
+  
+  @AfterEach
+  public void tearDown() {
+    resultKeyValuePairs.clear();
+    jsonPath.clear();
+  }
+
+  @Test
+  public void testSingleObjectJsonPath() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON);
+    jsonPath.add(JSON_FIRSTNAME_PATH);
+    jsonPathProvider.setPaths(jsonPath);
+    try {
+      resultKeyValuePairs = jsonPathProvider.extract(msg);
+      jsonPathProvider.insert(msg, resultKeyValuePairs);
+    } catch (ServiceException e) {
+      e.printStackTrace();
+      fail();
+    }
+    assertEquals(JSON, msg.getContent());
+  }
+  
+  @Test
+  public void testExpressionJsonPath() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON);
+    jsonPath.add(JSON_EXPRESSION_PATH);
+    jsonPathProvider.setPaths(jsonPath);
+    try {
+      resultKeyValuePairs = jsonPathProvider.extract(msg);
+      jsonPathProvider.insert(msg, resultKeyValuePairs);
+    } catch (ServiceException e) {
+      e.printStackTrace();
+      fail();
+    }
+    assertEquals(JSON, msg.getContent());
+  }
+  
+  @Test
+  public void testMultipleJsonPaths() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON);
+    jsonPath.add(JSON_FIRSTNAME_PATH);
+    jsonPath.add(JSON_LASTNAME_PATH);
+    jsonPath.add(JSON_AGE_PATH);
+    jsonPathProvider.setPaths(jsonPath);
+    try {
+      resultKeyValuePairs = jsonPathProvider.extract(msg);
+      jsonPathProvider.insert(msg, resultKeyValuePairs);
+    } catch (ServiceException e) {
+      e.printStackTrace();
+      fail();
+    }
+    assertEquals(JSON, msg.getContent());
+  }
+  
+  @Test
+  public void testMultiObjectJsonPathException() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON);
+    jsonPath.add(JSON_MULTI_OBJECT_PATH);
+    jsonPathProvider.setPaths(jsonPath);
+    Throwable exception =  Assertions.assertThrows(ServiceException.class, () -> {
+      resultKeyValuePairs = jsonPathProvider.extract(msg);
+    });
+    assertEquals(String.format(JSON_NON_OBJECT_PATH_EXCEPTION_MESSAGE, JSON_MULTI_OBJECT_PATH), exception.getMessage());
+  }
+  
+  @Test
+  public void testArrayJsonPathException() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON);
+    jsonPath.add(JSON_ARRAY_PATH);
+    jsonPathProvider.setPaths(jsonPath);
+    Throwable exception =  Assertions.assertThrows(ServiceException.class, () -> {
+      resultKeyValuePairs = jsonPathProvider.extract(msg);
+    });
+    assertEquals(String.format(JSON_NON_OBJECT_PATH_EXCEPTION_MESSAGE, JSON_ARRAY_PATH), exception.getMessage());
+  }
+  
+  @Test
+  public void testNonJson() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(NON_JSON);
+    jsonPath.add(JSON_FIRSTNAME_PATH);
+    jsonPathProvider.setPaths(jsonPath);
+    Throwable exception =  Assertions.assertThrows(ServiceException.class, () -> {
+      resultKeyValuePairs = jsonPathProvider.extract(msg);
+    });
+    assertEquals(String.format(JSON_PATH_NOT_FOUND_EXCEPTION_MESSAGE, JSON_FIRSTNAME_PATH), exception.getMessage());
+  }
+  
+  @Test
+  public void testNonExistentJsonPath() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON);
+    jsonPath.add(JSON_NON_EXISTENT_PATH);
+    jsonPathProvider.setPaths(jsonPath);
+    Throwable exception =  Assertions.assertThrows(ServiceException.class, () -> {
+      resultKeyValuePairs = jsonPathProvider.extract(msg);
+    });
+    assertEquals(String.format(JSON_PATH_NOT_FOUND_EXCEPTION_MESSAGE, JSON_NON_EXISTENT_PATH), exception.getMessage());
+  }
+  
+  @Test
+  public void testInvalidJsonPath() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON);
+    jsonPath.add(JSON_INVALID_PATH);
+    jsonPathProvider.setPaths(jsonPath);
+    Throwable exception =  Assertions.assertThrows(ServiceException.class, () -> {
+      resultKeyValuePairs = jsonPathProvider.extract(msg);
+    });
+    assertEquals(String.format(JSON_INVALID_PATH_EXCEPTION_MESSAGE, JSON_INVALID_PATH), exception.getMessage());
+  }
+  
+}

--- a/interlok-json/src/test/java/com/adaptris/core/json/path/JsonPathBuilderTest.java
+++ b/interlok-json/src/test/java/com/adaptris/core/json/path/JsonPathBuilderTest.java
@@ -2,7 +2,6 @@ package com.adaptris.core.json.path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.booleanThat;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;

--- a/interlok-json/src/test/java/com/adaptris/core/json/path/JsonPathBuilderTest.java
+++ b/interlok-json/src/test/java/com/adaptris/core/json/path/JsonPathBuilderTest.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +23,7 @@ public class JsonPathBuilderTest {
       + "\",\"age\":26,\"address\":{\"streetAddress\":\"street\",\"city\":\"city\",\"postalCode"
       + "\":\"TW12 3RR\"},\"phoneNumbers\":[{\"type\":\"mobile\",\"number\":\"000-000-000\"},"
       + "{\"type\":\"home\",\"number\":\"111-111-111\"}]}";
-  
+
   private static final String NON_JSON = "not json";
 
   private static final String JSON_FIRSTNAME_PATH = "$.firstName";
@@ -35,18 +34,18 @@ public class JsonPathBuilderTest {
   private static final String JSON_EXPRESSION_PATH = "$.phoneNumbers.[0].number";
   private static final String JSON_INVALID_PATH = "invalid json path";
   private static final String JSON_NON_EXISTENT_PATH = "$.thirdName";
-  
+
   private static Map<String, String> resultKeyValuePairs;
   private static List<String> jsonPath;
   private static JsonPathBuilder jsonPathProvider;
-  
+
   @BeforeAll
   public static void setUp() {
-    resultKeyValuePairs  = new LinkedHashMap<>();
-    jsonPath = new ArrayList<String>();
+    resultKeyValuePairs = new LinkedHashMap<>();
+    jsonPath = new ArrayList<>();
     jsonPathProvider = new JsonPathBuilder();
   }
-  
+
   @AfterEach
   public void tearDown() {
     resultKeyValuePairs.clear();
@@ -57,7 +56,7 @@ public class JsonPathBuilderTest {
   public void testSingleObjectJsonPath() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON);
     jsonPath.add(JSON_FIRSTNAME_PATH);
-    jsonPathProvider.setPaths(jsonPath);
+    jsonPathProvider.setJsonPaths(jsonPath);
     try {
       resultKeyValuePairs = jsonPathProvider.extract(msg);
       jsonPathProvider.insert(msg, resultKeyValuePairs);
@@ -67,13 +66,13 @@ public class JsonPathBuilderTest {
     }
     assertEquals(JSON, msg.getContent());
   }
-  
+
   @Test
   public void testSingleObjectJsonPathFromMetadata() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON);
     msg.addMetadata("jsonPath", JSON_FIRSTNAME_PATH);
     jsonPath.add("%message{jsonPath}");
-    jsonPathProvider.setPaths(jsonPath);
+    jsonPathProvider.setJsonPaths(jsonPath);
     try {
       resultKeyValuePairs = jsonPathProvider.extract(msg);
       jsonPathProvider.insert(msg, resultKeyValuePairs);
@@ -83,12 +82,12 @@ public class JsonPathBuilderTest {
     }
     assertEquals(JSON, msg.getContent());
   }
-  
+
   @Test
   public void testExpressionJsonPath() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON);
     jsonPath.add(JSON_EXPRESSION_PATH);
-    jsonPathProvider.setPaths(jsonPath);
+    jsonPathProvider.setJsonPaths(jsonPath);
     try {
       resultKeyValuePairs = jsonPathProvider.extract(msg);
       jsonPathProvider.insert(msg, resultKeyValuePairs);
@@ -98,14 +97,14 @@ public class JsonPathBuilderTest {
     }
     assertEquals(JSON, msg.getContent());
   }
-  
+
   @Test
   public void testMultipleJsonPaths() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON);
     jsonPath.add(JSON_FIRSTNAME_PATH);
     jsonPath.add(JSON_LASTNAME_PATH);
     jsonPath.add(JSON_AGE_PATH);
-    jsonPathProvider.setPaths(jsonPath);
+    jsonPathProvider.setJsonPaths(jsonPath);
     try {
       resultKeyValuePairs = jsonPathProvider.extract(msg);
       jsonPathProvider.insert(msg, resultKeyValuePairs);
@@ -115,55 +114,55 @@ public class JsonPathBuilderTest {
     }
     assertEquals(JSON, msg.getContent());
   }
-  
+
   @Test
   public void testMultiObjectJsonPathException() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON);
     jsonPath.add(JSON_MULTI_OBJECT_PATH);
-    jsonPathProvider.setPaths(jsonPath);
+    jsonPathProvider.setJsonPaths(jsonPath);
     assertThrows(ServiceException.class, () -> {
       resultKeyValuePairs = jsonPathProvider.extract(msg);
     }, "JSON path does not resolve to a single object.");
   }
-  
+
   @Test
   public void testArrayJsonPathException() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON);
     jsonPath.add(JSON_ARRAY_PATH);
-    jsonPathProvider.setPaths(jsonPath);
+    jsonPathProvider.setJsonPaths(jsonPath);
     assertThrows(ServiceException.class, () -> {
       resultKeyValuePairs = jsonPathProvider.extract(msg);
     }, "JSON path does not resolve to a single object.");
   }
-  
+
   @Test
   public void testNonJson() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(NON_JSON);
     jsonPath.add(JSON_FIRSTNAME_PATH);
-    jsonPathProvider.setPaths(jsonPath);
+    jsonPathProvider.setJsonPaths(jsonPath);
     assertThrows(ServiceException.class, () -> {
       resultKeyValuePairs = jsonPathProvider.extract(msg);
     }, "Non JSON message.");
   }
-  
+
   @Test
   public void testNonExistentJsonPath() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON);
     jsonPath.add(JSON_NON_EXISTENT_PATH);
-    jsonPathProvider.setPaths(jsonPath);
+    jsonPathProvider.setJsonPaths(jsonPath);
     assertThrows(ServiceException.class, () -> {
       resultKeyValuePairs = jsonPathProvider.extract(msg);
     }, "JSON path does not exist.");
   }
-  
+
   @Test
   public void testInvalidJsonPath() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JSON);
     jsonPath.add(JSON_INVALID_PATH);
-    jsonPathProvider.setPaths(jsonPath);
+    jsonPathProvider.setJsonPaths(jsonPath);
     assertThrows(ServiceException.class, () -> {
       resultKeyValuePairs = jsonPathProvider.extract(msg);
     }, "Invalid JSON path.");
   }
-  
+
 }


### PR DESCRIPTION
## Motivation

The Json path builder that can be added as part of the optional component which then allows support for JSON payloads when using the newly added Interlok path encryption/decryption services.

The PR for that can be found here: https://github.com/adaptris/interlok/pull/1249

## Modification

A class that implements the PathBuilder Interface: JsonPathBuilder
a test class for the above that have been added.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [n/a] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [n/a] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [n/a] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI
- [n/a] Remove any config/license annotations
- [n/a] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Two new services that you can define paths for that will encrypt/decrypt the content of those paths in a given message.

## Testing

Follow the same testing as defined in this PR: https://github.com/adaptris/interlok/pull/1249
