### PR TITLE
Added a new service that executes a configured service for each Json array element

### DIFF
--- a/interlok-json/src/main/java/com/adaptris/core/json/ForEachJsonArrayElementService.java
+++ b/interlok-json/src/main/java/com/adaptris/core/json/ForEachJsonArrayElementService.java
@@ -1,0 +1,83 @@
+package com.adaptris.core.json;
+
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.Service;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.ServiceImp;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.interlok.config.DataInputParameter;
+import com.adaptris.interlok.config.DataOutputParameter;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import lombok.Getter;
+import lombok.Setter;
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
+import net.minidev.json.parser.JSONParser;
+
+@XStreamAlias("for-each-json-array-element-service")
+@ComponentProfile(
+    summary = "Executes a service for each Json array element.")
+public class ForEachJsonArrayElementService extends ServiceImp {
+
+  @Getter
+  @Setter
+  private DataInputParameter<String> jsonArraySource;
+  
+  @Getter
+  @Setter
+  private DataOutputParameter<String> perElementDestination;
+
+  @Getter
+  @Setter
+  private Service forEachElementService;
+  
+  @InputFieldDefault(value="Permissive")
+  @AdvancedConfig(rare=true)
+  @Getter
+  @Setter
+  private JsonParseModeEnum jsonParseMode;
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    final JSONParser jsonParser = new JSONParser(getDefaultJsonParseMode().parserMode());
+    Object object;
+    try {
+      object = jsonParser.parse(jsonArraySource.extract(msg));
+
+      if (object instanceof JSONObject) {
+        throw new ServiceException("Object is not a Json Array.");
+      } else if (object instanceof JSONArray) {
+        final JSONArray array = (JSONArray) object;
+
+        for (final Object element : array) {
+          perElementDestination.insert(((JSONObject) element).toJSONString(), msg);
+          forEachElementService.doService(msg);
+        }
+      }
+    } catch (Exception ex) {
+      ExceptionHelper.rethrowServiceException(ex);
+    }
+  }
+
+  private JsonParseModeEnum getDefaultJsonParseMode() {
+    return getJsonParseMode() == null ? JsonParseModeEnum.Permissive : getJsonParseMode();
+  }
+  
+  @Override
+  public void prepare() throws CoreException {
+  }
+
+  @Override
+  protected void initService() throws CoreException {
+  }
+
+  @Override
+  protected void closeService() {
+  }
+
+}

--- a/interlok-json/src/main/java/com/adaptris/core/json/JsonParseModeEnum.java
+++ b/interlok-json/src/main/java/com/adaptris/core/json/JsonParseModeEnum.java
@@ -1,0 +1,35 @@
+package com.adaptris.core.json;
+
+import net.minidev.json.parser.JSONParser;
+
+public enum JsonParseModeEnum {
+
+  Permissive {
+    @Override
+    public int parserMode() {
+      return JSONParser.MODE_PERMISSIVE;
+    }
+  },
+  RFC4627 {
+    @Override
+    public int parserMode() {
+      return JSONParser.MODE_RFC4627;
+    }
+  },
+  Json_Simple {
+    @Override
+    public int parserMode() {
+      return JSONParser.MODE_JSON_SIMPLE;
+    }
+  },
+  Strict {
+    @Override
+    public int parserMode() {
+      return JSONParser.MODE_STRICTEST;
+    }
+  };
+  
+  public abstract int parserMode();
+    
+  
+}

--- a/interlok-json/src/test/java/com/adaptris/core/json/ForEachJsonArrayElementServiceTest.java
+++ b/interlok-json/src/test/java/com/adaptris/core/json/ForEachJsonArrayElementServiceTest.java
@@ -1,0 +1,178 @@
+package com.adaptris.core.json;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.MultiPayloadAdaptrisMessageImp;
+import com.adaptris.core.MultiPayloadMessageFactory;
+import com.adaptris.core.Service;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.ServiceImp;
+import com.adaptris.core.common.StringPayloadDataInputParameter;
+import com.adaptris.core.common.StringPayloadDataOutputParameter;
+import com.adaptris.core.services.LogMessageService;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
+
+public class ForEachJsonArrayElementServiceTest extends ExampleServiceCase{
+
+  private String jsonSource = "[\r\n"
+      + "    {\r\n"
+      + "      \"name\": \"string\",\r\n"
+      + "      \"type\": \"SAXON_XSLT\",\r\n"
+      + "      \"url\": \"http://localhost:8090/custom-test/transform\"\r\n"
+      + "    },\r\n"
+      + "    {\r\n"
+      + "      \"name\": \"string\",\r\n"
+      + "      \"type\": \"XPATH_METADATA\",\r\n"
+      + "      \"metadataKey\": \"string\",\r\n"
+      + "      \"xpath\": \"string\"\r\n"
+      + "    },\r\n"
+      + "    {\r\n"
+      + "      \"name\": \"string\",\r\n"
+      + "      \"type\": \"SomethingElse\",\r\n"
+      + "      \"url\": \"http://localhost:8090/custom-test/transform\"\r\n"
+      + "    }\r\n"
+      + "  ]";
+  
+  private String notAnArrayJsonSource = "{\r\n"
+      + "      \"name\": \"string\",\r\n"
+      + "      \"type\": \"SAXON_XSLT\",\r\n"
+      + "      \"url\": \"http://localhost:8090/custom-test/transform\"\r\n"
+      + "    }";
+  
+  private ForEachJsonArrayElementService service;
+  private AdaptrisMessage message;
+    
+  @Mock private Service mockService;
+  
+  @BeforeEach
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    service = new ForEachJsonArrayElementService();
+    service.setForEachElementService(mockService);
+    service.setJsonArraySource(new StringPayloadDataInputParameter());
+    service.setPerElementDestination(new StringPayloadDataOutputParameter());
+    message = DefaultMessageFactory.getDefaultInstance().newMessage(jsonSource);
+  }
+  
+  @Test
+  public void testMultipleElements() throws Exception {
+    service.doService(message);
+    
+    verify(mockService, times(3)).doService(message);
+  }
+  
+  @Test
+  public void testMultipleElementsSimpleMode() throws Exception {
+    service.setJsonParseMode(JsonParseModeEnum.Json_Simple);
+    service.doService(message);
+    
+    verify(mockService, times(3)).doService(message);
+  }
+  
+  @Test
+  public void testMultipleElementsRFCRFC4627Mode() throws Exception {
+    service.setJsonParseMode(JsonParseModeEnum.RFC4627);
+    service.doService(message);
+    
+    verify(mockService, times(3)).doService(message);
+  }
+  
+  @Test
+  public void testWithMultiPayload() throws Exception {
+    message = new MultiPayloadMessageFactory().newMessage("json", jsonSource.getBytes());
+    ((MultiPayloadAdaptrisMessageImp)message).switchPayload("json");
+    
+    service.doService(message);
+    
+    verify(mockService, times(3)).doService(message);
+  }
+  
+  @Test
+  public void testNoArray() {
+    try {
+      message.setContent(notAnArrayJsonSource, message.getContentEncoding());
+      service.doService(message);
+      fail("Payload does not contain an array, should fail");
+    } catch (ServiceException ex) {
+      // expected
+    }
+  }
+  
+  @Test
+  public void testEachPayload() throws Exception {
+    service.setForEachElementService(new TestService());
+    service.doService(message);
+  }
+  
+  @Test
+  public void testNoJson() {
+    try {
+      message.setContent("<xml-element>", message.getContentEncoding());
+      service.setJsonParseMode(JsonParseModeEnum.Strict);
+      service.doService(message);
+      fail("Payload does not contain json, should fail");
+    } catch (ServiceException ex) {
+      // expected
+    }
+  }
+  
+  @Override
+  protected Object retrieveObjectForSampleConfig() {
+    service.setForEachElementService(new LogMessageService());
+    return service;
+  }
+  
+  class TestService extends ServiceImp {
+
+    static List<String> expectedPayloads;
+    static {
+      expectedPayloads = new ArrayList<>();
+      expectedPayloads.add("SAXON_XSLT");
+      expectedPayloads.add("XPATH_METADATA");
+      expectedPayloads.add("SomethingElse");
+    }
+    
+    @Override
+    public void doService(AdaptrisMessage msg) throws ServiceException {      
+      int index = expectedPayloads.indexOf(msg.resolve("%payload{jsonpath:$.type}"));
+      if(index >= 0) {
+        expectedPayloads.remove(index);
+      } else {
+        throw new ServiceException("Payload not expected.");
+      }
+    }
+
+    @Override
+    public void prepare() throws CoreException {
+      // TODO Auto-generated method stub
+      
+    }
+
+    @Override
+    protected void initService() throws CoreException {
+      // TODO Auto-generated method stub
+      
+    }
+
+    @Override
+    protected void closeService() {
+      // TODO Auto-generated method stub
+      
+    }
+    
+  }
+
+}


### PR DESCRIPTION
## Motivation

We needed a way to execute a configured service for each json array element in a given data source.
There are other options like Json array splitters, however if you don't want a cloned message for each invocation, then the splitter doesn't work for your needs.

## Modification

New service to perform a loop for each array element and a new configurable enum to set the Json parse mode.

## PR Checklist

- [x] been self-reviewed.

