### PR TITLE
INTERLOK-4552: Update json-jq-tranform service to set target as a dat…

### DIFF
--- a/interlok-jq/src/main/java/com/adaptris/core/json/jq/JsonJqTransform.java
+++ b/interlok-jq/src/main/java/com/adaptris/core/json/jq/JsonJqTransform.java
@@ -106,11 +106,11 @@ public class JsonJqTransform extends ServiceImp {
     }
   }
 
-  private Reader buildReader(AdaptrisMessage msg) throws InterlokException, IOException {
+  protected Reader buildReader(AdaptrisMessage msg) throws InterlokException, IOException {
     return queryTarget != null ? new StringReader(queryTarget.extract(msg)) : msg.getReader();
   }
 
-  private void writeResult(AdaptrisMessage msg, Object result, ObjectMapper mapper) throws InterlokException, IOException {
+  protected void writeResult(AdaptrisMessage msg, Object result, ObjectMapper mapper) throws InterlokException, IOException {
     try (Writer w = outputTarget != null ? new StringWriter() : msg.getWriter();
       JsonGenerator generator = mapper.getFactory().createGenerator(w).useDefaultPrettyPrinter()) {
       generator.writeObject(result);

--- a/interlok-jq/src/main/java/com/adaptris/core/json/jq/JsonJqTransform.java
+++ b/interlok-jq/src/main/java/com/adaptris/core/json/jq/JsonJqTransform.java
@@ -27,8 +27,11 @@ import com.adaptris.core.metadata.RemoveAllMetadataFilter;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.LoggingHelper;
+import com.adaptris.interlok.InterlokException;
 import com.adaptris.interlok.config.DataInputParameter;
+import com.adaptris.interlok.config.DataOutputParameter;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -40,8 +43,7 @@ import net.thisptr.jackson.jq.Version;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import java.io.Reader;
-import java.io.Writer;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -68,6 +70,14 @@ public class JsonJqTransform extends ServiceImp {
 
   @Valid
   @AdvancedConfig
+  private DataInputParameter<String> queryTarget;
+
+  @Valid
+  @AdvancedConfig
+  private DataOutputParameter<String> outputTarget;
+
+  @Valid
+  @AdvancedConfig
   private MetadataFilter metadataFilter;
 
   public JsonJqTransform() {
@@ -80,24 +90,33 @@ public class JsonJqTransform extends ServiceImp {
   public void doService(AdaptrisMessage msg) throws ServiceException {
     log.trace("Beginning doService in {}", LoggingHelper.friendlyName(this));
     ObjectMapper mapper = new ObjectMapper();
-    try (Reader reader = msg.getReader();
-        Writer w = msg.getWriter();
-        JsonGenerator generator = mapper.getFactory().createGenerator(w).useDefaultPrettyPrinter()) {
-      JsonQuery q = JsonQuery.compile(querySource.extract(msg), Version.LATEST);
-      JsonNode jsonNode = mapper.readTree(reader);
+    final List<JsonNode> result = new ArrayList<>();
+    try {
+      try (Reader reader = buildReader(msg)) {
+        JsonQuery q = JsonQuery.compile(querySource.extract(msg), Version.LATEST);
+        JsonNode jsonNode = mapper.readTree(reader);
 
-      final List<JsonNode> result = new ArrayList<>();
-      q.apply(createScope(mapper, msg), jsonNode, out -> result.add(out));
-
-      if (result.size() == 1) {
-        generator.writeObject(result.get(0));
+        q.apply(createScope(mapper, msg), jsonNode, out -> result.add(out));
       }
-      else {
-        generator.writeObject(result);
-      }
+      Object _result = result.size() == 1 ? result.get(0) : result;
+      writeResult(msg, _result, mapper);
     }
     catch (Exception e) {
       throw ExceptionHelper.wrapServiceException(e);
+    }
+  }
+
+  private Reader buildReader(AdaptrisMessage msg) throws InterlokException, IOException {
+    return queryTarget != null ? new StringReader(queryTarget.extract(msg)) : msg.getReader();
+  }
+
+  private void writeResult(AdaptrisMessage msg, Object result, ObjectMapper mapper) throws InterlokException, IOException {
+    try (Writer w = outputTarget != null ? new StringWriter() : msg.getWriter();
+      JsonGenerator generator = mapper.getFactory().createGenerator(w).useDefaultPrettyPrinter()) {
+      generator.writeObject(result);
+      if (outputTarget != null) {
+        outputTarget.insert(w.toString(), msg);
+      }
     }
   }
 
@@ -133,8 +152,35 @@ public class JsonJqTransform extends ServiceImp {
     this.querySource = Args.notNull(query, "querySource");
   }
 
+
+  public DataInputParameter<String> getQueryTarget() {
+    return queryTarget;
+  }
+
+  public void setQueryTarget(DataInputParameter<String> queryTarget) {
+    this.queryTarget = queryTarget;
+  }
+
+  public DataOutputParameter<String> getOutputTarget() {
+    return outputTarget;
+  }
+
+  public void setOutputTarget(DataOutputParameter<String> outputTarget) {
+    this.outputTarget = outputTarget;
+  }
+
   public JsonJqTransform withQuerySource(DataInputParameter<String> query) {
     setQuerySource(query);
+    return this;
+  }
+
+  public JsonJqTransform withQueryTarget(DataInputParameter<String> target) {
+    setQueryTarget(target);
+    return this;
+  }
+
+  public JsonJqTransform withOutputTarget(DataOutputParameter<String> outputTarget) {
+    setOutputTarget(outputTarget);
     return this;
   }
 

--- a/interlok-jq/src/test/java/com/adaptris/core/json/jq/JsonJqTransformTest.java
+++ b/interlok-jq/src/test/java/com/adaptris/core/json/jq/JsonJqTransformTest.java
@@ -1,11 +1,15 @@
 package com.adaptris.core.json.jq;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
 import java.util.EnumSet;
 
+import com.adaptris.core.ServiceException;
 import com.adaptris.core.common.*;
+import com.adaptris.interlok.InterlokException;
 import org.junit.jupiter.api.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -19,6 +23,7 @@ import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.ReadContext;
 import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import org.mockito.Mockito;
 
 public class JsonJqTransformTest extends ExampleServiceCase {
 
@@ -45,6 +50,19 @@ public class JsonJqTransformTest extends ExampleServiceCase {
     assertNotNull(ctx.read("$.status-description"));
     assertNotNull(ctx.read("$.status-code"));
     assertNotNull(ctx.read("$.status-id"));
+  }
+
+
+  @Test
+  public void testServiceException() throws Exception {
+    JsonJqTransform service = spy(JsonJqTransform.class).withQuerySource(new ConstantDataInputParameter(METADATA_QUERY));
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance()
+            .newMessage(SAMPLE_DATA);
+    msg.addMetadata(new MetadataElement("greeting", "Hello World"));
+    doThrow(new InterlokException()).when(service).buildReader(any());
+    assertThrows(ServiceException.class, () -> {
+      execute(service, msg);
+    });
   }
 
   @Test

--- a/interlok-jq/src/test/java/com/adaptris/core/json/jq/JsonJqTransformTest.java
+++ b/interlok-jq/src/test/java/com/adaptris/core/json/jq/JsonJqTransformTest.java
@@ -4,11 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 import java.util.EnumSet;
+
+import com.adaptris.core.common.*;
 import org.junit.jupiter.api.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.MetadataElement;
-import com.adaptris.core.common.ConstantDataInputParameter;
 import com.adaptris.core.metadata.NoOpMetadataFilter;
 import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 import com.jayway.jsonpath.Configuration;
@@ -62,6 +63,73 @@ public class JsonJqTransformTest extends ExampleServiceCase {
     assertNotFound(ctx, "$.status-id");
     assertNotNull(ctx.read("$.greeting"));
     assertEquals("Hello World", ctx.read("$.greeting"));
+  }
+
+  @Test
+  public void testService_WithPayloadQueryTargetAndPayloadOutputTarget() throws Exception {
+    JsonJqTransform service = new JsonJqTransform().withQuerySource(new ConstantDataInputParameter(METADATA_QUERY))
+            .withQueryTarget(new StringPayloadDataInputParameter())
+            .withOutputTarget(new StringPayloadDataOutputParameter())
+            .withMetadataFilter(new NoOpMetadataFilter());
+
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(SAMPLE_DATA);
+    msg.addMetadata(new MetadataElement("greeting", "Hello World"));
+    execute(service, msg);
+    assertNotNull(msg.getContent());
+    System.err.println(msg.getContent());
+    ReadContext ctx = parse(msg);
+    assertNotFound(ctx, "$.status-description");
+    assertNotFound(ctx, "$.status-code");
+    assertNotFound(ctx, "$.status-id");
+    assertNotNull(ctx.read("$.greeting"));
+    assertEquals("Hello World", ctx.read("$.greeting"));
+  }
+
+  @Test
+  public void testService_WithMetadataQueryTargetAndPayloadOutputTarget() throws Exception {
+    MetadataDataInputParameter mip = new MetadataDataInputParameter();
+    JsonJqTransform service = new JsonJqTransform().withQuerySource(new ConstantDataInputParameter(SAMPLE_QUERY))
+            .withQueryTarget(mip)
+            .withOutputTarget(new StringPayloadDataOutputParameter())
+            .withMetadataFilter(new NoOpMetadataFilter());
+
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance()
+            .newMessage("{}");
+    msg.addMetadata(new MetadataElement(mip.getMetadataKey(), SAMPLE_DATA));
+    execute(service, msg);
+    assertNotNull(msg.getContent());
+    System.err.println(msg.getContent());
+    ReadContext ctx = parse(msg);
+    assertNotNull(ctx.read("$.status-description"));
+    assertNotNull(ctx.read("$.status-code"));
+    assertNotNull(ctx.read("$.status-id"));
+
+  }
+
+  @Test
+  public void testService_WithMetadataQueryTargetAndMetadataOutputTarget() throws Exception {
+    MetadataDataInputParameter mip = new MetadataDataInputParameter();
+    MetadataDataOutputParameter mop = new MetadataDataOutputParameter();
+    JsonJqTransform service = new JsonJqTransform().withQuerySource(new ConstantDataInputParameter(SAMPLE_QUERY))
+            .withQueryTarget(mip)
+            .withOutputTarget(mop)
+            .withMetadataFilter(new NoOpMetadataFilter());
+
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance()
+            .newMessage("{}");
+    msg.addMetadata(new MetadataElement(mip.getMetadataKey(), SAMPLE_DATA));
+    execute(service, msg);
+    assertNotNull(msg.getContent());
+    System.err.println(msg.getContent());
+    ReadContext ctx = parse(msg);
+    assertNotFound(ctx, "$.status-description");
+    assertNotFound(ctx, "$.status-code");
+    assertNotFound(ctx, "$.status-id");
+
+    ReadContext  ctx2 = parse(msg.getMetadataValue(mop.getMetadataKey()));
+    assertNotNull(ctx2.read("$.status-description"));
+    assertNotNull(ctx2.read("$.status-code"));
+    assertNotNull(ctx2.read("$.status-id"));
   }
 
   private void assertNotFound(ReadContext ctx, String path) {


### PR DESCRIPTION
## Motivation
https://adaptris.atlassian.net/browse/INTERLOK-4552

## Modification
 I’ve added 2 additional fields:

queryTarget: This is a DataInputParameter<String> which is what the query should run against

outputTarget: This is a DataOutputParameter<String> which is where the result of the query should be stored.

## PR Checklist

- [x] been self-reviewed.
- [ ] Added javadocs for most classes and all non-trivial methods
- [x ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ x] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result



## Testing

See JsonJqTransformTest.testService_WithMetadataQueryTargetAndMetadataOutputTarget, testService_WithMetadataQueryTargetAndPayloadOutputTarget and testService_WithPayloadQueryTargetAndPayloadOutputTarget
