### PR TITLE
Feature/interlok 4554 jwt creator to use runtime expressions

### DIFF
--- a/interlok-json-web-token/README.md
+++ b/interlok-json-web-token/README.md
@@ -9,7 +9,7 @@ For more information about JSON Web Tokens [see here](https://github.com/jwtk/jj
 ## JSON Create
 
 The json-create service will create a JWT string from discreet values of
-***issuer***, ***subject***, ***audience***, ***expiration***, ***no
+***issuer***, ***subject***, ***audience***, ***expiration***, ***not
 before***. It can also include custom key/value pairs. The output will
 be a JWT string.
 

--- a/interlok-json-web-token/src/main/java/com/adaptris/core/jwt/JWTCreator.java
+++ b/interlok-json-web-token/src/main/java/com/adaptris/core/jwt/JWTCreator.java
@@ -1,9 +1,7 @@
 package com.adaptris.core.jwt;
 
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -21,6 +19,7 @@ import com.adaptris.core.ServiceImp;
 import com.adaptris.core.jwt.secrets.SecretConfigurator;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.KeyValuePairSet;
+import com.adaptris.util.text.DateFormatUtil;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 import io.jsonwebtoken.JwtBuilder;
@@ -91,21 +90,21 @@ public class JWTCreator extends ServiceImp {
   @Setter
   @Valid
   @AdvancedConfig(rare = true)
-  @InputFieldHint(expression = true, friendly = "dd/mm/yyyy")
+  @InputFieldHint(expression = true)
   private String issuedAt;
 
   @Getter
   @Setter
   @NotNull
   @Valid
-  @InputFieldHint(expression = true, friendly = "dd/mm/yyyy")
+  @InputFieldHint(expression = true)
   private String expiration;
 
   @Getter
   @Setter
   @NotNull
   @Valid
-  @InputFieldHint(expression = true, friendly = "dd/mm/yyyy")
+  @InputFieldHint(expression = true)
   private String notBefore;
 
   @NotNull
@@ -120,8 +119,6 @@ public class JWTCreator extends ServiceImp {
   @AdvancedConfig
   @InputFieldHint(expression = true)
   private KeyValuePairSet customClaims;
-
-  final static String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SZ";
 
   /**
    * <p>
@@ -165,21 +162,18 @@ public class JWTCreator extends ServiceImp {
   }
 
   private Date parseOrResolveDateField(String inputString, AdaptrisMessage message) throws ParseException {
-    final SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT);
-    dateFormat.setLenient(false);
-
     final String resolvedString = message.resolve(inputString);
 
     if (!resolvedString.equals(inputString)) {
-      return dateFormat.parse(resolvedString);
+      return DateFormatUtil.parse(resolvedString);
     }
 
-    return dateFormat.parse(inputString);
+    return DateFormatUtil.parse(inputString);
   }
 
   private Date getJwtIssuedAt(AdaptrisMessage message) throws ParseException {
     if (issuedAt == null) {
-      issuedAt = new SimpleDateFormat(DATE_FORMAT).format(new Date());
+      issuedAt = new Date().toString();
     }
     return parseOrResolveDateField(issuedAt, message);
   }

--- a/interlok-json-web-token/src/main/java/com/adaptris/core/jwt/JWTCreator.java
+++ b/interlok-json-web-token/src/main/java/com/adaptris/core/jwt/JWTCreator.java
@@ -1,6 +1,9 @@
 package com.adaptris.core.jwt;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -88,19 +91,22 @@ public class JWTCreator extends ServiceImp {
   @Setter
   @Valid
   @AdvancedConfig(rare = true)
-  private Date issuedAt;
+  @InputFieldHint(expression = true, friendly = "dd/mm/yyyy")
+  private String issuedAt;
 
   @Getter
   @Setter
   @NotNull
   @Valid
-  private Date expiration;
+  @InputFieldHint(expression = true, friendly = "dd/mm/yyyy")
+  private String expiration;
 
   @Getter
   @Setter
   @NotNull
   @Valid
-  private Date notBefore;
+  @InputFieldHint(expression = true, friendly = "dd/mm/yyyy")
+  private String notBefore;
 
   @NotNull
   @Valid
@@ -115,6 +121,8 @@ public class JWTCreator extends ServiceImp {
   @InputFieldHint(expression = true)
   private KeyValuePairSet customClaims;
 
+  final static String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SZ";
+
   /**
    * <p>
    * Apply the service to the message.
@@ -128,14 +136,17 @@ public class JWTCreator extends ServiceImp {
   @Override
   public void doService(AdaptrisMessage message) throws ServiceException {
     try {
+      final Date notBeforeDate = parseOrResolveDateField(notBefore, message);
+      final Date expirationDate = parseOrResolveDateField(expiration, message);
+
       JwtBuilder builder = Jwts.builder()
           .subject(message.resolve(subject))
           .audience().add(message.resolve(audience))
           .and()
-          .notBefore(notBefore)
+          .notBefore(notBeforeDate)
           .issuer(message.resolve(issuer))
-          .expiration(expiration)
-          .issuedAt(jwtIssuedAt())
+          .expiration(expirationDate)
+          .issuedAt(getJwtIssuedAt(message))
           .id(jwtId());
 
       builder = secret.configure(builder);
@@ -152,9 +163,25 @@ public class JWTCreator extends ServiceImp {
       throw new ServiceException(e);
     }
   }
-  
-  private Date jwtIssuedAt() {
-    return Optional.ofNullable(issuedAt).orElseGet(() -> new Date());
+
+  private Date parseOrResolveDateField(String inputString, AdaptrisMessage message) throws ParseException {
+    final SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT);
+    dateFormat.setLenient(false);
+
+    final String resolvedString = message.resolve(inputString);
+
+    if (!resolvedString.equals(inputString)) {
+      return dateFormat.parse(resolvedString);
+    }
+
+    return dateFormat.parse(inputString);
+  }
+
+  private Date getJwtIssuedAt(AdaptrisMessage message) throws ParseException {
+    if (issuedAt == null) {
+      issuedAt = new SimpleDateFormat(DATE_FORMAT).format(new Date());
+    }
+    return parseOrResolveDateField(issuedAt, message);
   }
   
   private String jwtId() {

--- a/interlok-json-web-token/src/test/java/com/adaptris/core/jwt/JWTCreatorTest.java
+++ b/interlok-json-web-token/src/test/java/com/adaptris/core/jwt/JWTCreatorTest.java
@@ -1,10 +1,10 @@
 package com.adaptris.core.jwt;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import java.text.SimpleDateFormat;
+import java.util.Date;
 
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
@@ -23,13 +23,12 @@ import io.jsonwebtoken.Claims;
 import lombok.SneakyThrows;
 
 public class JWTCreatorTest extends JWTCommonTest {
-  private SimpleDateFormat PARSER = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 
   @Test
   public void testCreate() throws Exception {
     JWTCreator service = (JWTCreator) retrieveObjectForSampleConfig();
     service.setId("4f044322-5db3-44d2-a698-15b754bd7a05");
-    service.setIssuedAt(PARSER.parse("2020-01-01T00:00:00.0-0000"));
+    service.setIssuedAt("2020-01-01T00:00:00.0-0000");
     Base64EncodedSecret secret = new Base64EncodedSecret();
     secret.setSecret(KEY);
     service.setSecret(secret);
@@ -96,6 +95,23 @@ public class JWTCreatorTest extends JWTCommonTest {
     }
   }
 
+  @Test
+  void testParseOrResolveDateField_ResolvesDifferentString() throws Exception {
+    JWTCreator creator = new JWTCreator();
+    String input = "SOME_INPUT";
+    String resolved = "2020-01-01T00:00:00.0-0000";
+
+    AdaptrisMessage message = mock(AdaptrisMessage.class);
+    when(message.resolve(input)).thenReturn(resolved);
+
+    var method = JWTCreator.class.getDeclaredMethod("parseOrResolveDateField", String.class, AdaptrisMessage.class);
+    method.setAccessible(true);
+
+    Object result = method.invoke(creator, input, message);
+    assertNotNull(result);
+    assertInstanceOf(Date.class, result);
+  }
+
   @SneakyThrows
   @Override
   protected Object retrieveObjectForSampleConfig() {
@@ -103,8 +119,8 @@ public class JWTCreatorTest extends JWTCommonTest {
     creator.setIssuer("me");
     creator.setSubject("Bob");
     creator.setAudience("you");
-    creator.setExpiration(PARSER.parse("2040-12-31T00:00:00.0-0000"));
-    creator.setNotBefore(PARSER.parse("2020-01-01T00:00:00.0-0000"));
+    creator.setExpiration("2040-12-31T00:00:00.000-0000");
+    creator.setNotBefore("2020-01-01T00:00:00.0-0000");
     creator.setSecret(getPGPSecret());
     return creator;
   }


### PR DESCRIPTION
## JWT Creator Service using Runtime Expressions

This change implements the ability to use runtime expressions in the JWT Creator service for expiration, notBefore and issuedAt fields.
