### PR TITLE
Show Error Summary in S3 Retry Store

### DIFF
--- a/interlok-json/src/main/java/com/adaptris/core/json/JsonBlobListRenderer.java
+++ b/interlok-json/src/main/java/com/adaptris/core/json/JsonBlobListRenderer.java
@@ -37,6 +37,7 @@ public class JsonBlobListRenderer implements BlobListRenderer {
         mapInsert(obj, "lastModified", blob.getLastModified());
         mapInsert(obj, "name", blob.getName());
         mapInsert(obj, "size", blob.getSize());
+        mapInsert(obj, "errorSummary", blob.getErrorSummary());
         generator.writeObject(obj);
       }
       generator.writeEndArray();

--- a/interlok-json/src/test/java/com/adaptris/core/json/JsonBlobListRendererTest.java
+++ b/interlok-json/src/test/java/com/adaptris/core/json/JsonBlobListRendererTest.java
@@ -41,6 +41,21 @@ public class JsonBlobListRendererTest {
   }
 
   @Test
+  public void testRender_WithErrorSummary() throws Exception {
+    JsonBlobListRenderer render = new JsonBlobListRenderer();
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    Collection<RemoteBlob> blobs = createBlobsWithErrorSummary(5);
+    render.render(blobs, msg);
+    Configuration jsonConfig = new Configuration.ConfigurationBuilder().jsonProvider(new JsonSmartJsonProvider())
+        .mappingProvider(new JacksonMappingProvider()).options(EnumSet.noneOf(Option.class)).build();
+    String content = msg.getContent();
+    ReadContext context = JsonPath.parse(content, jsonConfig);
+    assertEquals(Integer.valueOf(5), context.read("$.length()"));
+    assertEquals("bucket", context.read("$[0].bucket"));
+    assertEquals("Error details", context.read("$[0].errorSummary"));
+  }
+
+  @Test
   public void testRenderLines() throws Exception {
     JsonBlobListRenderer render = new JsonBlobListRendererLines();
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
@@ -98,6 +113,15 @@ public class JsonBlobListRendererTest {
     for (int i = 0; i < count; i++) {
       result.add(new RemoteBlob.Builder().setBucket("bucket").setLastModified(new Date().getTime()).setName("File_" + i)
           .setSize(10L).build());
+    }
+    return result;
+  }
+
+  private static Collection<RemoteBlob> createBlobsWithErrorSummary(int count) {
+    List<RemoteBlob> result = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      result.add(new RemoteBlob.Builder().setBucket("bucket").setLastModified(new Date().getTime()).setName("File_" + i)
+          .setSize(10L).setErrorSummary("Error details").build());
     }
     return result;
   }


### PR DESCRIPTION
## Motivation

We need to show the first line of stacktrace as a seperate property in the remote-blob-list-as-json report builder (Used alongside S3RetryStore by NGN). This adds the new property in thye report builder component.

## Modification

Implemented errorSummary in remote blob json report builder.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [x] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI
- [x] Remove any config/license annotations
- [x] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

The error summary showing as part of the json report builder.

## Testing

Unit tests updated and end to end tested with all the updated components.
